### PR TITLE
fix: update global BEAM memories across sessions

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5035,9 +5035,13 @@ class BeamMemory:
             params.append(importance)
         if not updates:
             return False
+        # Match the visibility contract used by get(), forget_working(), and
+        # invalidate(): global memories are addressable across sessions, while
+        # session-scoped memories remain private to their creating session.
         params.extend([memory_id, self.session_id])
         cursor.execute(
-            f"UPDATE working_memory SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
+            f"UPDATE working_memory SET {', '.join(updates)} "
+            "WHERE id = ? AND (session_id = ? OR scope = 'global')",
             params
         )
         affected = cursor.rowcount

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -848,19 +848,39 @@ class Mnemosyne:
         if not updates:
             return False
 
-        params.extend([memory_id, self.session_id])
         with _deferred_commits(self.conn):
-            cursor.execute(
-                f"UPDATE memories SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
-                params
-            )
-            self.conn.commit()
+            # Authorize from the authoritative BEAM working row. Global rows
+            # may be updated cross-session; session-scoped rows remain private.
+            owner = cursor.execute(
+                """
+                SELECT session_id FROM working_memory
+                WHERE id = ? AND (session_id = ? OR scope = 'global')
+                """,
+                (memory_id, self.session_id),
+            ).fetchone()
+            if owner is None:
+                # Preserve owner-only updates for old legacy-only rows without
+                # letting their fallback authorize a foreign working-memory row.
+                params.extend([memory_id, self.session_id])
+                legacy_where = "id = ? AND session_id = ?"
+            else:
+                # The legacy mirror has no scope; update it by the BEAM row's
+                # owning session after BEAM has authorized the operation.
+                params.extend([memory_id, owner["session_id"]])
+                legacy_where = "id = ? AND session_id = ?"
 
-            # Sync BEAM working_memory
-            self.beam.update_working(memory_id, content=content, importance=importance)
+            cursor.execute(
+                f"UPDATE memories SET {', '.join(updates)} WHERE {legacy_where}",
+                params,
+            )
+            legacy_updated = cursor.rowcount > 0
+            self.conn.commit()
+            beam_updated = self.beam.update_working(
+                memory_id, content=content, importance=importance
+            )
 
         self._emit_wrapper("MEMORY_UPDATED", memory_id, content=content, importance=importance)
-        return cursor.rowcount > 0
+        return legacy_updated or beam_updated
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """Mark a memory as expired or superseded. Delegates to BEAM."""

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -878,9 +878,12 @@ class Mnemosyne:
             beam_updated = self.beam.update_working(
                 memory_id, content=content, importance=importance
             )
+            updated = legacy_updated or beam_updated
 
+        if not updated:
+            return False
         self._emit_wrapper("MEMORY_UPDATED", memory_id, content=content, importance=importance)
-        return legacy_updated or beam_updated
+        return True
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """Mark a memory as expired or superseded. Delegates to BEAM."""

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -38,6 +38,7 @@ def _same_utc_day_future(
         return None
     return candidate
 from mnemosyne.core.memory import Mnemosyne
+from mnemosyne.core.streaming import EventType
 
 
 @pytest.fixture
@@ -138,6 +139,75 @@ def test_mnemosyne_update_rejects_dual_written_private_memory_cross_session(temp
         "SELECT content FROM memories WHERE id = ?", (memory_id,)
     ).fetchone()[0]
     assert legacy_content == "private before"
+
+
+def test_mnemosyne_update_unknown_memory_emits_no_event(temp_db):
+    memory = Mnemosyne(session_id="session-a", db_path=temp_db).enable_streaming()
+
+    assert memory.update("unknown-memory", content="after") is False
+    assert memory.stream.get_buffer(event_types=[EventType.MEMORY_UPDATED]) == []
+
+
+def test_mnemosyne_update_foreign_private_memory_emits_no_event(temp_db):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("private before", source="test", scope="session")
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db).enable_streaming()
+
+    assert updater.update(memory_id, content="private after") is False
+    assert writer.get(memory_id)["content"] == "private before"
+    assert updater.stream.get_buffer(event_types=[EventType.MEMORY_UPDATED]) == []
+
+
+def test_mnemosyne_update_rolls_back_and_emits_no_event_when_beam_write_fails(
+    temp_db, monkeypatch
+):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("before", source="test", scope="global")
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db).enable_streaming()
+
+    def fail_second_dual_write(*args, **kwargs):
+        raise RuntimeError("forced BEAM update failure")
+
+    monkeypatch.setattr(updater.beam, "update_working", fail_second_dual_write)
+
+    with pytest.raises(RuntimeError, match="forced BEAM update failure"):
+        updater.update(memory_id, content="after", importance=0.9)
+
+    legacy_content, legacy_importance = writer.conn.execute(
+        "SELECT content, importance FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()
+    assert (legacy_content, legacy_importance) == ("before", 0.5)
+    unchanged = writer.get(memory_id)
+    assert (unchanged["content"], unchanged["importance"]) == ("before", 0.5)
+    assert updater.stream.get_buffer(event_types=[EventType.MEMORY_UPDATED]) == []
+
+
+def test_mnemosyne_update_emits_once_after_dual_write_commit(temp_db):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("before", source="test", scope="global")
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db).enable_streaming()
+    observed = []
+
+    def observe(event):
+        legacy = updater.conn.execute(
+            "SELECT content, importance FROM memories WHERE id = ?", (memory_id,)
+        ).fetchone()
+        working = updater.conn.execute(
+            "SELECT content, importance FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+        observed.append((event, legacy, working, updater.conn.in_transaction))
+
+    updater.stream.on(EventType.MEMORY_UPDATED, observe)
+
+    assert updater.update(memory_id, content="after", importance=0.9) is True
+    events = updater.stream.get_buffer(event_types=[EventType.MEMORY_UPDATED])
+    assert len(events) == 1
+    assert events[0].memory_id == memory_id
+    assert len(observed) == 1
+    _, legacy, working, in_transaction = observed[0]
+    assert tuple(legacy) == ("after", 0.9)
+    assert tuple(working) == ("after", 0.9)
+    assert in_transaction is False
 
 
 def test_mnemosyne_update_preserves_legacy_only_session_compatibility(temp_db):

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -89,6 +89,81 @@ def test_get_working_memory_respects_global_cross_session_visibility(temp_db):
     assert reader.get(private_id) is None
 
 
+def test_update_working_respects_global_cross_session_visibility(temp_db):
+    writer = BeamMemory(session_id="session-a", db_path=temp_db)
+    global_id = writer.remember("global before", source="test", scope="global")
+    private_id = writer.remember("private before", source="test", scope="session")
+
+    updater = BeamMemory(session_id="session-b", db_path=temp_db)
+    assert updater.update_working(global_id, content="global after") is True
+    assert updater.get(global_id)["content"] == "global after"
+
+    assert updater.update_working(private_id, content="private after") is False
+    assert writer.get(private_id)["content"] == "private before"
+
+
+def test_mnemosyne_update_reports_success_for_beam_only_global_memory(temp_db):
+    writer = BeamMemory(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("beam only before", source="test", scope="global")
+
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db)
+    assert updater.update(memory_id, content="beam only after") is True
+    assert updater.get(memory_id)["content"] == "beam only after"
+
+
+def test_mnemosyne_update_keeps_dual_written_global_memory_in_sync(temp_db):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("dual before", source="test", scope="global")
+
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db)
+    assert updater.update(memory_id, content="dual after", importance=0.9) is True
+    updated = updater.get(memory_id)
+    assert updated["content"] == "dual after"
+    assert updated["importance"] == 0.9
+    legacy_content, legacy_importance = updater.conn.execute(
+        "SELECT content, importance FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()
+    assert legacy_content == "dual after"
+    assert legacy_importance == 0.9
+
+
+def test_mnemosyne_update_rejects_dual_written_private_memory_cross_session(temp_db):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = writer.remember("private before", source="test", scope="session")
+
+    updater = Mnemosyne(session_id="session-b", db_path=temp_db)
+    assert updater.update(memory_id, content="private after") is False
+    assert writer.get(memory_id)["content"] == "private before"
+    legacy_content = updater.conn.execute(
+        "SELECT content FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()[0]
+    assert legacy_content == "private before"
+
+
+def test_mnemosyne_update_preserves_legacy_only_session_compatibility(temp_db):
+    writer = Mnemosyne(session_id="session-a", db_path=temp_db)
+    memory_id = "legacy-only-memory"
+    writer.conn.execute(
+        """
+        INSERT INTO memories (id, content, source, timestamp, session_id, importance)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (memory_id, "legacy before", "test", "2026-01-01T00:00:00", "session-a", 0.5),
+    )
+    writer.conn.commit()
+
+    assert writer.update(memory_id, content="legacy after") is True
+    assert writer.conn.execute(
+        "SELECT content FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()[0] == "legacy after"
+
+    other_session = Mnemosyne(session_id="session-b", db_path=temp_db)
+    assert other_session.update(memory_id, content="should not update") is False
+    assert writer.conn.execute(
+        "SELECT content FROM memories WHERE id = ?", (memory_id,)
+    ).fetchone()[0] == "legacy after"
+
+
 class _FakeAnnotations:
     def __init__(self, rows):
         self._rows = rows

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -177,6 +177,32 @@ class TestUpdate:
                                                    "content": "new"}))
         assert r["status"] == "updated"
 
+    def test_dispatch_update_allows_global_memory_from_another_session(self, tmp_path):
+        db_path = Path(tmp_path) / "test.db"
+        writer = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = writer.remember("global before", scope="global")
+        provider = _build_provider(BeamMemory(session_id="session-b", db_path=db_path))
+
+        response = json.loads(provider.handle_tool_call(
+            "mnemosyne_update", {"memory_id": memory_id, "content": "global after"}
+        ))
+
+        assert response["status"] == "updated"
+        assert writer.get(memory_id)["content"] == "global after"
+
+    def test_dispatch_update_rejects_private_memory_from_another_session(self, tmp_path):
+        db_path = Path(tmp_path) / "test.db"
+        writer = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = writer.remember("private before", scope="session")
+        provider = _build_provider(BeamMemory(session_id="session-b", db_path=db_path))
+
+        response = json.loads(provider.handle_tool_call(
+            "mnemosyne_update", {"memory_id": memory_id, "content": "private after"}
+        ))
+
+        assert response["status"] == "not_found"
+        assert writer.get(memory_id)["content"] == "private before"
+
 
 # ---------------------------------------------------------------------------
 # Forget tool

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -7,7 +7,6 @@ update, forget, import, diagnose) plus the 7 already-existing tools.
 """
 
 import json
-import pytest
 from pathlib import Path
 
 from mnemosyne.core.beam import BeamMemory


### PR DESCRIPTION
## Summary

Fixes #580 without weakening session isolation.

- Authorizes cross-session updates only for `scope="global"` working memories.
- Keeps session-scoped memories private.
- Synchronizes the legacy row after BEAM has established visibility, while preserving legacy-only same-session compatibility.
- Adds BEAM, core, and Hermes provider dispatch regressions.

## Why this path

`get`, `forget_working`, and `invalidate` already make global working memories visible across sessions. `update_working` is the inconsistent mutation boundary. The legacy table has no scope column, so BEAM remains the authorization source before its compatibility row is updated.

## Why not remove `session_id` entirely?

That would allow a caller with a known ID to update a session-scoped memory from another session.

## Non-goals

No schema migration, ownership-model redesign, lifecycle change, or docs update.

## Verification

```text
MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q tests/test_beam.py tests/test_provider_all_15_tools.py tests/test_mcp_server.py
184 passed, 9 skipped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enables cross-session updates for `scope="global"` BEAM working memories.
- Preserves session isolation for `scope="session"` memories.
- Synchronizes legacy rows after BEAM authorization succeeds.
- Retains legacy-only same-session compatibility.
- Emits `MEMORY_UPDATED` only after committed writes.
- Adds core, BEAM, and Hermes provider dispatch regression coverage.

## Architectural impact

This is the right call for the tiered memory architecture. It aligns BEAM working-memory update authorization with existing global-memory visibility rules. It does not change episodic memory, retrieval, consolidation, veracity, schemas, ownership, or lifecycle behavior.

The privacy posture remains unchanged. Global memories support cross-session management. Session-scoped memories remain private.

The local-first design remains intact. Updates remain database-backed and require no remote service. Dual-written BEAM and legacy records remain synchronized, with rollback protection when the BEAM write fails.

`Mnemosyne.update()` now supports BEAM-only global memories and preserves legacy compatibility. Hermes provider dispatch benefits from the corrected core path. No direct MCP or CLI implementation changes are included.

The tests cover global, private, BEAM-only, dual-written, legacy-only, rollback, event ordering, transaction gating, and provider-dispatch behavior. No benchmark methodology changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->