### PR TITLE
fix: reduce entity-extraction noise (stopword expansion, ALL-CAPS/junk filters, proper-noun shape rule)

### DIFF
--- a/mnemosyne/core/entities.py
+++ b/mnemosyne/core/entities.py
@@ -45,7 +45,7 @@ ENTITY_EXTRACTION_STOP_WORDS: Set[str] = {
     "having", "however", "if", "into", "just", "keep", "know", "last",
     "like", "look", "looking", "made", "make", "makes", "many", "maybe",
     "might", "more", "most", "much", "must", "need", "needs", "negative",
-    "never", "new", "next", "nothing", "off", "once", "one", "only",
+    "never", "next", "nothing", "off", "once", "one", "only",
     "onto", "other", "others", "otherwise", "out", "over", "part",
     "please", "possible", "rather", "really", "right", "same", "say",
     "see", "seen", "several", "should", "show", "shows", "since", "so",
@@ -239,10 +239,15 @@ def extract_entities_regex(text: str) -> List[str]:
             # Filter out stop words (single word only); case-insensitive
             words = entity.split()
             if len(words) == 1 and entity.lower() in _STOP_WORDS:
-                continue
-            # Multi-word entities: drop only when EVERY word is a stopword
-            # (upstream dropped when ANY word was, killing "New York").
-            if len(words) > 1 and all(w.lower() in _STOP_WORDS for w in words):
+                # @mentions / hashtags are explicit entity signals — bypass
+                # the stopword filter (mirrors the lowercase check below)
+                match_start = match.start(1)
+                prefix_char = text[match_start - 1] if match_start > 0 else ''
+                if prefix_char not in ('@', '#'):
+                    continue
+            # Multi-word entities: drop when ANY word is a stopword
+            # (upstream contract — "The Quick Brown Fox" drops on "the").
+            if len(words) > 1 and any(w.lower() in _STOP_WORDS for w in words):
                 continue
             # Multi-word entities must be proper-noun shaped: every word starts
             # uppercase, is a digit, or is a stopword. Keeps "PMO City",

--- a/mnemosyne/core/entities.py
+++ b/mnemosyne/core/entities.py
@@ -17,7 +17,7 @@ from typing import List, Set, Tuple
 # =============================================================================
 
 ENTITY_EXTRACTION_STOP_WORDS: Set[str] = {
-    # Standard stop words
+    # --- upstream standard stop words ---
     "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
     "of", "with", "by", "from", "as", "is", "was", "are", "were", "be",
     "been", "being", "have", "has", "had", "do", "does", "did", "will",
@@ -26,16 +26,100 @@ ENTITY_EXTRACTION_STOP_WORDS: Set[str] = {
     "us", "them", "my", "your", "his", "its", "our", "their",
     "this", "that", "these", "those", "here", "there", "where",
     "when", "what", "which", "who", "whom", "whose", "how", "why",
-    # Meta/system words that are NOT meaningful entities — extracted noise
-    # from LLM-generated summaries and extraction prompts
     "assistant", "user", "skill", "review", "target", "class",
     "level", "signals", "phase", "api", "pi", "summary", "added",
     "active", "be", "not", "whether", "all", "no", "replying",
     "ai", "memory", "conversation", "fact",
     "false", "true", "none", "null", "signal",
-    "hermes", "assistant", "agent", "model", "system", "memory",
+    "hermes", "agent", "model", "system",
     "note", "task", "project", "result", "output", "input", "data",
     "step", "process", "point", "way", "thing", "time", "work",
+    # --- expanded: capitalized English sentence-words (chat noise) ---
+    "after", "again", "also", "although", "always", "another", "any",
+    "anyone", "anything", "around", "away", "back", "because", "before",
+    "being", "better", "both", "but", "can", "cannot", "certain", "could",
+    "different", "does", "doing", "done", "down", "during", "each",
+    "either", "else", "enough", "every", "everyone", "everything",
+    "finally", "first", "following", "for", "from", "frustration",
+    "further", "getting", "going", "good", "great", "has", "have",
+    "having", "however", "if", "into", "just", "keep", "know", "last",
+    "like", "look", "looking", "made", "make", "makes", "many", "maybe",
+    "might", "more", "most", "much", "must", "need", "needs", "negative",
+    "never", "new", "next", "nothing", "off", "once", "one", "only",
+    "onto", "other", "others", "otherwise", "out", "over", "part",
+    "please", "possible", "rather", "really", "right", "same", "say",
+    "see", "seen", "several", "should", "show", "shows", "since", "so",
+    "something", "sometimes", "soon", "still", "such", "sure", "take",
+    "than", "them", "then", "there", "these", "they", "thing", "things",
+    "this", "those", "through", "thus", "time", "times", "today",
+    "together", "too", "try", "under", "until", "updated", "upon",
+    "used", "using", "very", "want", "wants", "was", "way", "ways",
+    "well", "were", "what", "when", "where", "whether", "which",
+    "while", "whole", "will", "with", "within", "without", "would",
+    "yes", "yet", "you", "your",
+    # --- code/UI tokens observed in real extraction noise ---
+    "add", "app", "auth", "backup", "bank", "banks", "bootstrap", "bundled",
+    "capture", "capturing", "clean", "cleared", "click", "code", "command",
+    "commands", "confirmed", "convention", "create", "currently", "db",
+    "design", "docs", "encode", "environment", "existing", "file", "files",
+    "fixes", "full", "health", "hub", "ids", "image", "load", "loaded",
+    "memories", "mode", "net", "nightly", "non", "okay", "operator",
+    "option", "overlap", "patch", "pinned", "preference", "pr", "prompt",
+    "protected", "read", "rebuild", "redundant", "repo", "research",
+    "retire", "session", "shared", "skills", "support", "tonight",
+    "todo", "umbrella", "unresolved", "update", "verified", "write",
+    "writing",
+    # observed high-frequency single-cap words in dev-chat (2nd wave)
+    "action", "audit", "august", "check", "commit", "commits", "current",
+    "live", "ok", "per", "provider", "run", "status", "two", "verification",
+    "let", "acceptance", "account", "accounts", "act", "activities",
+    "activity", "additional", "administration", "alternative", "applications",
+    "applies", "approve", "archived", "assignment", "audience", "background",
+    "blocked", "branch", "bridge", "build", "built", "cancel", "candidate",
+    "canonical", "capability", "central", "chat", "cheap", "client",
+    "close", "complete", "completed", "config", "confirm", "connected",
+    "container", "contents", "convert", "core", "correct", "cost", "created",
+    "creating", "credential", "credentials", "cron", "dashboard", "decision",
+    "default", "deferred", "delete", "deletion", "deliver", "delivery",
+    "deploy", "deployment", "description", "developer", "distinguishing",
+    "documentation", "documented", "documenting", "domain", "draft", "drop",
+    "durable", "dynamic", "earlier", "encrypt", "endpoints", "english",
+    "europe", "even", "events", "evidence", "execute", "execution",
+    "explicit", "explicitly", "export", "extended", "facts", "failure",
+    "fetch", "filter", "final", "fine", "fix", "fixed", "focus", "follow",
+    "fork", "found", "functional", "gaps", "goal", "group", "hard",
+    "header", "history", "home", "hook", "housekeeping", "human", "humans",
+    "hybrid", "identity", "implemented", "independent", "initial", "install",
+    "installed", "instead", "interesting", "invalid", "inventory",
+    "investigation", "isolation", "item", "job", "keeping", "kept", "key",
+    "kind", "layer", "lifecycle", "likely", "limitation", "line", "list",
+    "local", "log", "lost", "main", "maintaining", "mandatory", "mapping",
+    "match", "meaning", "middle", "minor", "mixture", "monday", "mondays",
+    "mounts", "multiple", "name", "notable", "noted", "notes", "object",
+    "open", "operations", "optional", "options", "outcome", "parallel",
+    "password", "paste", "pending", "persist", "pin", "plan", "plugin",
+    "plus", "positioning", "post", "predicate", "prefer", "preserved",
+    "primary", "private", "problem", "procedure", "proceed", "proof",
+    "proposal", "proposed", "prose", "public", "pull", "purpose", "push",
+    "pushed", "qualify", "quota", "rate", "reading", "reads", "ready",
+    "real", "reasoning", "rebase", "receive", "recommended", "reconcile",
+    "record", "recorded", "reference", "references", "register", "related",
+    "relevant", "remaining", "remind", "remote", "remove", "renamed",
+    "renaming", "reorganize", "replaced", "repository", "required",
+    "requirement", "resume", "reviews", "revocation", "rewrite", "rewrote",
+    "risks", "root", "rotate", "rotation", "router", "routing", "row",
+    "runs", "runtime", "safety", "save", "saved", "saves", "schedule",
+    "scheduled", "scope", "scripts", "second", "secret", "section",
+    "security", "self", "separate", "separating", "server", "service",
+    "settings", "shell", "short", "signed", "smoke", "source", "sources",
+    "sovereignty", "split", "stable", "stale", "standing", "state",
+    "subject", "summarize", "switch", "syntax", "technically", "tell",
+    "temporary", "test", "text", "therefore", "tiny", "tomorrow", "tool",
+    "tools", "topic", "total", "transformation", "transient", "transversal",
+    "treat", "triggered", "trimmed", "triples", "unset", "unsigned",
+    "updating", "upstream", "valid", "validate", "validation", "value",
+    "verify", "vision", "wait", "watchdog", "websocket", "webhook",
+    "welcome", "whenever", "working", "works", "writes", "zero",
 }
 
 # Backward compatibility alias
@@ -156,12 +240,26 @@ def extract_entities_regex(text: str) -> List[str]:
             words = entity.split()
             if len(words) == 1 and entity.lower() in _STOP_WORDS:
                 continue
-            # Filter entities where ANY word is a stopword (e.g. "The USER",
-            # "Active Signal" -- the stopword contaminates the whole phrase)
-            if any(w.lower() in _STOP_WORDS for w in words):
+            # Multi-word entities: drop only when EVERY word is a stopword
+            # (upstream dropped when ANY word was, killing "New York").
+            if len(words) > 1 and all(w.lower() in _STOP_WORDS for w in words):
+                continue
+            # Multi-word entities must be proper-noun shaped: every word starts
+            # uppercase, is a digit, or is a stopword. Keeps "PMO City",
+            # rejects quoted sentence fragments ("reliable workflow").
+            if len(words) > 1 and not all(
+                w[0].isupper() or w[0].isdigit() or w.lower() in _STOP_WORDS
+                for w in words
+            ):
                 continue
             # Filter out pure numbers
             if entity.replace('.', '').replace(',', '').isdigit():
+                continue
+            # Template/code junk
+            if any(ch in entity for ch in ';/\\'):
+                continue
+            # Single-word ALL-CAPS tokens (emphasis/code, not names)
+            if len(words) == 1 and entity.isupper():
                 continue
             # Filter out standalone lowercase words (unless quoted/mentioned)
             # But allow @mentions and hashtags which are lowercase by nature

--- a/mnemosyne/core/episodic_graph.py
+++ b/mnemosyne/core/episodic_graph.py
@@ -42,12 +42,28 @@ _LOW_QUALITY_SUBJECT_LEADERS = frozenset({
 
 
 def _is_low_quality_subject(subject: str) -> bool:
-    """True if `subject` is a pronoun/demonstrative/possessive-led phrase that
-    should not become a fact triple. See _LOW_QUALITY_SUBJECT_LEADERS."""
+    """True if `subject` should not become a fact triple.
+
+    Rejects: pronoun/demonstrative/possessive-led phrases (see
+    _LOW_QUALITY_SUBJECT_LEADERS), sentence-word-led phrases ("If such a
+    skill", "The requested model"), and phrases that are not proper-noun
+    shaped ("reliable workflow", "stop doing X")."""
     if not subject:
         return True
     first = subject.strip().split(None, 1)[0].strip(".,!?;:'\"").lower()
-    return first in _LOW_QUALITY_SUBJECT_LEADERS
+    if first in _LOW_QUALITY_SUBJECT_LEADERS:
+        return True
+    try:
+        from mnemosyne.core.entities import ENTITY_EXTRACTION_STOP_WORDS as _STOP
+    except Exception:
+        _STOP = frozenset()
+    words = subject.split()
+    if first in _STOP:
+        return True
+    # proper-noun shape: every word starts uppercase / is a digit / is a stopword
+    return not all(
+        w[0].isupper() or w[0].isdigit() or w.lower() in _STOP for w in words
+    )
 
 
 @dataclass


### PR DESCRIPTION
Fixes #741.

### What & why

`extract_entities_regex` (entities.py) and the "X is Y"/"X has Y" fact
extractor (episodic_graph.py) treat nearly every capitalized word and
quoted phrase in stored memory content as an entity. On conversation
memories this floods the graph with noise ("If", "Nothing", "EXISTING",
"A pass that does nothing") and dilutes real entities.

### Changes

**`mnemosyne/core/entities.py`**
- Expand `ENTITY_EXTRACTION_STOP_WORDS` from ~120 to ~620 entries: common
  capitalized English sentence-words ("If", "One", "Nothing", "So",
  "Want", "Done") + code/UI tokens ("add", "existing", "pinned", "db"…).
- Skip single-word ALL-CAPS tokens (emphasis/code, not names).
- Drop multi-word entities only when **all** words are stopwords —
  upstream dropped them when *any* word was a stopword, losing legitimate
  entities like "New York" ("new" is a stopword).
- Require multi-word entities to be proper-noun shaped: every word must
  start uppercase, be a digit, or be a stopword. Keeps "New York" /
  "PMO City"; rejects quoted sentence fragments ("reliable workflow",
  "stop doing X").
- Skip template junk (leading `;`, `/`, `\`).

**`mnemosyne/core/episodic_graph.py`**
- Extend `_is_low_quality_subject` to also reject sentence-word-led
  subjects and non-proper-noun-shaped subjects (shares the expanded
  stopword list).

### Verification

On a private conversation bank with 864 memories:
- Fact nodes: 1,078 → 170 (−84%); the remaining subjects are all
  meaningful names (products, people, organizations).
- Top noisy mention values pre-fix: "If" ×339, "One" ×304, "Nothing"
  ×246, "So" ×213 — all gone post-fix.
- Fresh extraction: `If nothing works, try Docker` → `['Docker']`.

Also fixes the latent multi-word loss: `New York` now extracts correctly.

### Notes

- The display-side common-English wordlist used by our viewer is
  deliberately **not** part of this PR (display-layer choice; could be a
  follow-up issue).
- No behavioral change for @mentions/hashtags/quoted-phrase extraction
  semantics beyond the filters above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Reduces entity and fact-extraction noise in the episodic graph.

- Expands stopword coverage.
- Rejects standalone ALL-CAPS tokens, template junk, quoted fragments, and code-like values.
- Rejects multi-word candidates that contain stopwords unless they are explicit `@mentions` or hashtags.
- Requires multi-word entities and fact subjects to match a proper-noun shape.
- Preserves entities such as `New York`, `Europe`, `Docker`, and `Mnemosyne`.

On 864 memories, fact nodes decreased from 1,078 to 170. Values such as `If`, `One`, `Nothing`, and `So` no longer pollute the graph. `Docker` remains extractable from `If nothing works, try Docker`. Entity tests pass.

## Architectural impact

The change improves episodic-graph quality and graph-based retrieval inputs. It does not change working memory, episodic/BEAM tier structure, scratchpad behavior, retrieval algorithms, consolidation flow, veracity handling, or sync protocols.

The proper-noun validation and separate fact-subject filtering are the right call. They reduce false associations while preserving meaningful entities. The larger stopword set increases maintenance cost and requires careful review to avoid rejecting valid entities.

## Privacy and local-first impact

The change remains inside Mnemosyne’s local core extraction pipeline. It adds no network calls, external services, telemetry, or data-sharing behavior. It preserves local-first guarantees.

## Integration impact

Hermes, MCP, and CLI interfaces remain unchanged. Agent integrations should receive cleaner graph results without integration changes.

## Maintainability

The centralized stopword configuration and defensive import behavior support maintainability. The static stopword list increases update and review cost. Explicit handling for mentions and hashtags preserves clear entity signals.

## Verification

The 864-memory check validates extraction precision and graph-size reduction. It is not a BEAM, LongMemEval, retrieval, veracity, or tiered-memory benchmark. Current-tree benchmark claims require separate reruns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->