### PR TITLE
fix(recovery): harden backup and restore paths

### DIFF
--- a/mnemosyne/dr/recovery.py
+++ b/mnemosyne/dr/recovery.py
@@ -13,7 +13,7 @@ import shutil
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 def get_default_paths():
@@ -38,31 +38,77 @@ def get_default_paths():
     else:
         root = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
         data_dir = root / "mnemosyne" / "data"
-    backup_dir = Path(os.environ.get("MNEMOSYNE_BACKUP_DIR", data_dir.parent / "backups"))
+    backup_dir = Path(
+        os.environ.get("MNEMOSYNE_BACKUP_DIR", data_dir.parent / "backups")
+    )
     db_path = data_dir / "mnemosyne.db"
     return data_dir, backup_dir, db_path
+
+
+def _allocate_unique_backup_path(backup_dir: Path, timestamp: str) -> Path:
+    """Atomically allocate a unique backup filename.
+
+    Uses ``O_CREAT | O_EXCL`` so two concurrent backups can never both select
+    and write the same name (a check-then-create sequence races). Retries with
+    a short random suffix until an exclusive create succeeds.
+    """
+    import secrets
+
+    suffix = ""
+    for _ in range(64):
+        name = f"mnemosyne_backup_{timestamp}{suffix}.db.gz"
+        candidate = backup_dir / name
+        try:
+            fd = os.open(str(candidate), os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            os.close(fd)
+            return candidate
+        except FileExistsError:
+            suffix = "_" + secrets.token_hex(3)
+    raise RuntimeError(f"Could not allocate a unique backup filename in {backup_dir}")
+
+
+def _unique_staged_path(db_path: Path) -> Path:
+    """A staged-restore path unique per invocation, so concurrent restores to
+    the same target cannot clobber each other's staging file."""
+    import secrets
+
+    token = secrets.token_hex(4)
+    return db_path.with_name(f"{db_path.name}.{os.getpid()}.{token}.restore_staged")
+
+
+def _fsync_dir(path: Path) -> None:
+    """fsync a directory so rename/replace metadata reaches durable storage."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY | os.O_DIRECTORY)
+    except (OSError, ValueError):
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
 
 
 def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
     """
     Create a compressed backup of the database.
-    
+
     Returns:
         Dict with backup_path, size, checksum, and timestamp
     """
     _, default_backup_dir, default_db = get_default_paths()
     db_path = db_path or default_db
     backup_dir = backup_dir or default_backup_dir
-    
+
     if not db_path.exists():
         raise FileNotFoundError(f"Database not found: {db_path}")
-    
+
     backup_dir.mkdir(parents=True, exist_ok=True)
-    
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup_name = f"mnemosyne_backup_{timestamp}.db.gz"
-    backup_path = backup_dir / backup_name
-    
+    backup_path = _allocate_unique_backup_path(backup_dir, timestamp)
+
     # Use sqlite3 online backup API instead of shutil.copyfileobj.
     # sqlite3.backup() is lock-aware (acquires read-lock), includes
     # uncommitted WAL frames, and is atomic — it won't produce a torn
@@ -75,14 +121,8 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
     # when copying vec0 virtual tables, AND dst.iterdump() (used to
     # serialize the in-memory backup to gzipped SQL) fails the same
     # way when introspecting the destination's vec0 schema.
-    # Mirrors the graceful-fallback pattern in core/beam.py.
-    def _load_sqlite_vec(conn):
-        try:
-            import sqlite_vec
-            conn.enable_load_extension(True)
-            sqlite_vec.load(conn)
-        except (ImportError, sqlite3.OperationalError):
-            pass  # optional extra; absence just means no vec0 tables
+    # Uses the module-level helper, which always re-disables extension
+    # loading afterward so no connection leaks an enabled state (I-1).
     _load_sqlite_vec(src)
     dst = sqlite3.connect(":memory:")
     _load_sqlite_vec(dst)
@@ -95,13 +135,17 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
         buf.write((line + "\n").encode("utf-8"))
     dst.close()
 
+    dump_bytes = buf.getvalue()
     with gzip.open(backup_path, "wb") as f_out:
-        f_out.write(buf.getvalue())
-    
-    # Calculate checksums
+        f_out.write(dump_bytes)
+
+    # Calculate checksums. ``dump_checksum`` covers the decompressed SQL dump
+    # payload so restore can detect corruption that survives gzip decompression
+    # (the older file-level checksums only covered the compressed container).
     db_checksum = hashlib.sha256(db_path.read_bytes()).hexdigest()[:16]
     backup_checksum = hashlib.sha256(backup_path.read_bytes()).hexdigest()[:16]
-    
+    dump_checksum = hashlib.sha256(dump_bytes).hexdigest()
+
     # Create metadata
     metadata = {
         "timestamp": timestamp,
@@ -109,126 +153,368 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
         "backup_size": backup_path.stat().st_size,
         "db_checksum": db_checksum,
         "backup_checksum": backup_checksum,
-        "compressed": True
+        "dump_checksum": dump_checksum,
+        "compressed": True,
     }
-    
+
     # Save metadata
-    meta_path = backup_path.with_suffix('.gz.json')
-    with open(meta_path, 'w') as f:
+    meta_path = backup_path.with_suffix(".gz.json")
+    with open(meta_path, "w") as f:
         json.dump(metadata, f, indent=2)
-    
+
     return {
         "backup_path": str(backup_path),
         "metadata_path": str(meta_path),
-        **metadata
+        **metadata,
     }
 
 
-def restore_backup(backup_path: Path, db_path: Path = None) -> Dict:
+def _load_sqlite_vec(conn: sqlite3.Connection) -> None:
+    """Load sqlite-vec on a connection when the extension is available.
+
+    Mirrors core/beam.py's graceful fallback: absence of sqlite-vec just means
+    no vec0 virtual tables to introspect.
+
+    Security: sqlite_vec.load() registers itself via SQLite's extension-loading
+    facility, which requires enable_load_extension(True). We MUST re-disable
+    extension loading before returning, regardless of whether the load
+    succeeded, failed with OperationalError, or the module was absent — callers
+    (notably restore_backup's executescript of backup-provided SQL) must never
+    run with extension loading left enabled. See security-privacy-audit-6a I-1.
     """
-    Restore database from a compressed backup.
-    
+    conn.enable_load_extension(True)
+    try:
+        import sqlite_vec
+
+        sqlite_vec.load(conn)
+    except (ImportError, sqlite3.OperationalError):
+        pass  # optional extra; absence/breakage just means no vec0 tables
+    finally:
+        # Always restore the default (extensions disabled) so untrusted SQL
+        # executed later on this connection cannot invoke load_extension.
+        conn.enable_load_extension(False)
+
+
+def _reject_active_sidecars(db_path: Path) -> None:
+    """Fail closed if WAL/SHM sidecars exist at the target.
+
+    A stale -wal/-shm alongside the main file means the on-disk state is the
+    union of the main file and uncommitted WAL frames. Atomically replacing
+    only the main file would silently drop those frames, so we refuse and let
+    an operator checkpoint/quiesce the writer first.
+    """
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(db_path.name + suffix)
+        if sidecar.exists():
+            raise RuntimeError(
+                f"Refusing to restore while an active sidecar exists: {sidecar}. "
+                f"Quiesce live writers and run 'PRAGMA wal_checkpoint(TRUNCATE)' "
+                f"before restoring."
+            )
+
+
+def _acquire_writer_lock(db_path: Path) -> Optional[sqlite3.Connection]:
+    """Acquire and HOLD an exclusive writer lock on the target.
+
+    A probe that begins and immediately rolls back does not cover the staging
+    window — a writer can start after the probe and race the replace. Instead
+    this takes ``BEGIN IMMEDIATE`` on a kept-open connection and returns it;
+    the caller releases it in a ``finally`` only after ``os.replace``. That
+    keeps SQLite's write lock held across the whole check-then-replace window
+    so a competing writer cannot enter.
+
+    Returns the locked connection (to be closed by the caller), or None when
+    the target does not exist yet (nothing to lock).
+    """
+    if not db_path.exists():
+        return None
+    lock_conn = sqlite3.connect(f"file:{db_path}?mode=rwc", uri=True)
+    try:
+        lock_conn.execute("PRAGMA busy_timeout=0")
+        lock_conn.execute("BEGIN IMMEDIATE")
+    except sqlite3.OperationalError as exc:
+        lock_conn.close()
+        raise RuntimeError(
+            f"Refusing to restore: a live writer appears to hold {db_path} "
+            f"({exc}). Stop all Mnemosyne processes before restoring."
+        ) from exc
+    return lock_conn
+
+
+def _release_writer_lock(conn: Optional[sqlite3.Connection]) -> None:
+    """Safely roll back and close a held writer-lock connection.
+
+    Returns None so call sites rebind (lock_conn = _release_writer_lock(
+    lock_conn)), making cleanup idempotent: the finally can call it on
+    a connection that was already released. Tolerates an already-closed
+    connection by swallowing sqlite3.Error. Replaces the duplicated
+    rollback()/close() blocks in the restore paths.
+    """
+    if conn is None:
+        return None
+    try:
+        conn.rollback()
+    except sqlite3.Error:
+        pass
+    try:
+        conn.close()
+    except sqlite3.Error:
+        pass
+    return None
+
+
+def _reacquire_writer_lock(db_path: Path) -> sqlite3.Connection:
+    """Re-acquire the exclusive writer lock on the *replacement* inode.
+
+    os.replace swaps the path to a new inode; the connection held since
+    before the replace still locks the OLD (now-unlinked) inode. This must be
+    called immediately after os.replace so the new inode is covered for
+    post-replace verify and rollback. It delegates to _acquire_writer_lock
+    (no second lock implementation) and raises a visible RuntimeError if
+    the new inode cannot be locked — never silently continuing.
+    """
+    return _acquire_writer_lock(db_path)
+
+
+def _fsync_path(path: Path) -> None:
+    """fsync a file path so the staged bytes reach durable storage."""
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def restore_backup(backup_path: Path, db_path: Path = None) -> Dict:
+    """Restore database from a compressed backup. Fail-closed.
+
+    Sequence:
+
+      1. Read the backup and its metadata sidecar. Metadata MUST be a readable
+         JSON object containing ``backup_checksum``; missing/malformed/unreadable
+         metadata or a missing file checksum is rejected (never silently
+         restored). ``dump_checksum`` is optional for compatibility with older
+         valid backups.
+      2. Verify the gzip file checksum and the decompressed dump checksum (when
+         recorded).
+      3. Reject active WAL/SHM sidecars. Acquire and HOLD an exclusive SQLite
+         writer lock on the target from this point through ``os.replace`` so a
+         competing writer cannot enter the staging window.
+      4. Rebuild the dump into a uniquely-named staged DB in the target
+         directory, load sqlite-vec where supported, and run
+         ``PRAGMA integrity_check``. fsync the staged file.
+      5. Preserve the original as ``.restore_preserved``, ``os.replace`` the
+         staged file onto the target, then immediately release the old-inode
+         writer lock and re-acquire ``BEGIN IMMEDIATE`` on the replacement
+         inode (the held lock does not follow the path across replace). Fsync
+         the parent dir after re-acquisition.
+      6. Run ``PRAGMA integrity_check`` under the new-inode lock. If it fails,
+         restore the preserved original in place, fsync, and raise — never
+         report success after a failed post-replace check.
+
+    Any error before the atomic replace leaves the original target untouched.
+    The held writer lock and the staged file are cleaned up in all cases.
+
     Args:
-        backup_path: Path to the .gz backup file
-        db_path: Destination database path (default: ~/.mnemosyne/data/mnemosyne.db)
-        
+        backup_path: Path to the .gz backup file.
+        db_path: Destination database path.
+
     Returns:
-        Dict with restore status and details
+        Dict with restore status and details. Raises on any validation
+        failure so the caller can report a structured error.
     """
     _, _, default_db = get_default_paths()
-    db_path = db_path or default_db
-    
+    db_path = Path(db_path or default_db)
+    backup_path = Path(backup_path)
+
     if not backup_path.exists():
         raise FileNotFoundError(f"Backup not found: {backup_path}")
-    
-    # Create emergency backup of current DB
-    if db_path.exists():
-        emergency_path = db_path.with_suffix('.emergency_backup.db')
-        shutil.copy2(db_path, emergency_path)
-    
-    # Decompress and restore using sqlite3 backup API
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with gzip.open(backup_path, "rb") as f_in:
-        sql_dump = f_in.read().decode("utf-8")
+    # --- 1. Read backup + require readable metadata ------------------------
+    meta_path = backup_path.with_suffix(".gz.json")
+    if not meta_path.exists():
+        raise RuntimeError(
+            f"Backup metadata sidecar not found: {meta_path}. Refusing to "
+            f"restore without checksum verification."
+        )
+    try:
+        with open(meta_path) as f:
+            metadata = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"Backup metadata is unreadable or malformed ({exc}). Refusing "
+            f"to restore without checksum verification."
+        ) from exc
+    if not isinstance(metadata, dict):
+        raise RuntimeError("Backup metadata is not a JSON object; refusing to restore.")
 
-    # Rebuild DB in-memory, then backup to target file
-    mem_db = sqlite3.connect(":memory:")
-    mem_db.executescript(sql_dump)
-    target_db = sqlite3.connect(str(db_path))
-    mem_db.backup(target_db)
-    mem_db.close()
-    target_db.close()
-    
-    # Verify restored database
-    is_valid = verify_integrity(db_path)
-    
+    with gzip.open(backup_path, "rb") as f_in:
+        dump_bytes = f_in.read()
+
+    backup_checksum = hashlib.sha256(backup_path.read_bytes()).hexdigest()[:16]
+    dump_checksum = hashlib.sha256(dump_bytes).hexdigest()
+
+    expected_backup = metadata.get("backup_checksum")
+    if not expected_backup:
+        raise RuntimeError(
+            "Backup metadata lacks a backup_checksum; refusing to restore "
+            "without file checksum verification."
+        )
+    if expected_backup != backup_checksum:
+        raise RuntimeError(
+            f"Backup file checksum mismatch: metadata={expected_backup} "
+            f"actual={backup_checksum}. The backup file is corrupted or was "
+            f"modified; refusing to restore."
+        )
+    # dump_checksum is optional: older valid backups predate it. Only verify
+    # when present, so this stays backward compatible.
+    expected_dump = metadata.get("dump_checksum")
+    if expected_dump and expected_dump != dump_checksum:
+        raise RuntimeError(
+            f"Backup payload checksum mismatch: metadata={expected_dump} "
+            f"actual={dump_checksum}. The decompressed dump is corrupted; "
+            f"refusing to restore."
+        )
+
+    # --- 2. Reject active sidecars ----------------------------------------
+    _reject_active_sidecars(db_path)
+
+    # --- 3. Acquire + hold the writer lock through replace ----------------
+    lock_conn = _acquire_writer_lock(db_path)
+    staged_path = _unique_staged_path(db_path)
+    preserved_path = db_path.with_name(db_path.name + ".restore_preserved")
+    preserved_existed = db_path.exists()
+    try:
+        # --- 4. Rebuild into the staged DB and validate ------------------
+        tmp_db = sqlite3.connect(str(staged_path))
+        _load_sqlite_vec(tmp_db)
+        try:
+            tmp_db.executescript(dump_bytes.decode("utf-8"))
+            integrity = tmp_db.execute("PRAGMA integrity_check").fetchone()[0]
+            if integrity != "ok":
+                raise RuntimeError(
+                    f"Staged restore failed integrity_check: {integrity}. "
+                    f"Refusing to replace target."
+                )
+            tmp_db.commit()
+            try:
+                tmp_db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except sqlite3.OperationalError:
+                pass
+            tmp_db.close()
+        except Exception:
+            try:
+                tmp_db.close()
+            except Exception:
+                pass
+            raise
+
+        _fsync_path(staged_path)
+
+        # --- 5. Preserve original, atomic replace -------------------------
+        # ponytail: rename changes SQLite's locked inode; re-acquire the native
+        # lock immediately after replace. A zero-window design needs an in-place
+        # restore or a separately governed sentinel lock.
+        if preserved_existed:
+            shutil.copy2(db_path, preserved_path)
+        os.replace(staged_path, db_path)
+        staged_path = None  # consumed by replace
+        # The old-inode lock no longer covers the path; release it and
+        # re-acquire on the replacement inode BEFORE any fsync or verify, so
+        # the vulnerable interval is just the release+acquire syscall pair.
+        lock_conn = _release_writer_lock(lock_conn)
+        lock_conn = _reacquire_writer_lock(db_path)
+        # Dir fsync persists the rename; dir fd is a different inode, safe
+        # under the held file lock. The staged bytes were fsynced pre-replace.
+        _fsync_dir(db_path.parent)
+
+        # --- 6. Post-replace integrity check; restore original on failure
+        if not verify_integrity(db_path):
+            # Never report success after a failed post-replace check. Restore
+            # the preserved original in place, fsync, and raise.
+            if preserved_existed and preserved_path.exists():
+                shutil.copy2(preserved_path, db_path)
+                _fsync_path(db_path)
+                _fsync_dir(db_path.parent)
+            raise RuntimeError(
+                f"Post-replace integrity_check failed for {db_path}. The "
+                f"original target was restored from {preserved_path}."
+            )
+    finally:
+        lock_conn = _release_writer_lock(lock_conn)
+        if staged_path is not None and staged_path.exists():
+            try:
+                staged_path.unlink()
+            except OSError:
+                pass
+
     return {
         "restored": True,
         "backup_used": str(backup_path),
         "database_path": str(db_path),
-        "integrity_check": is_valid
+        "integrity_check": True,
+        "backup_checksum": backup_checksum,
+        "dump_checksum": dump_checksum,
+        "preserved_original": str(preserved_path) if preserved_existed else None,
     }
 
 
 def emergency_restore(backup_dir: Path = None, db_path: Path = None) -> Dict:
     """
     Automatically restore from the most recent valid backup.
-    
+
     Returns:
         Dict with restore status
     """
     _, default_backup_dir, default_db = get_default_paths()
     backup_dir = backup_dir or default_backup_dir
     db_path = db_path or default_db
-    
+
     # Find all backups
     backups = sorted(backup_dir.glob("mnemosyne_backup_*.db.gz"), reverse=True)
-    
+
     if not backups:
         raise FileNotFoundError("No backups found in " + str(backup_dir))
-    
+
     # Try each backup until one works
     for backup in backups:
         try:
             result = restore_backup(backup, db_path)
             if result["integrity_check"]:
-                return {
-                    "restored": True,
-                    "backup_used": str(backup),
-                    "attempts": 1
-                }
+                return {"restored": True, "backup_used": str(backup), "attempts": 1}
         except Exception:
             continue
-    
+
     raise RuntimeError("All backups failed integrity check")
 
 
 def verify_integrity(db_path: Path = None) -> bool:
     """
     Verify SQLite database integrity.
-    
+
     Returns:
         True if database is valid, False otherwise
     """
     import sqlite3
-    
+
     _, _, default_db = get_default_paths()
     db_path = db_path or default_db
-    
+
     if not db_path.exists():
         return False
-    
+
     try:
         conn = sqlite3.connect(str(db_path))
         cursor = conn.cursor()
-        
+
         # Run PRAGMA integrity_check
         cursor.execute("PRAGMA integrity_check")
         result = cursor.fetchone()
-        
+
         conn.close()
-        
+
         return result[0] == "ok"
     except Exception:
         return False
@@ -237,137 +523,145 @@ def verify_integrity(db_path: Path = None) -> bool:
 def list_backups(backup_dir: Path = None) -> List[Dict]:
     """
     List all available backups with metadata.
-    
+
     Returns:
         List of backup information dictionaries
     """
     _, default_backup_dir, _ = get_default_paths()
     backup_dir = backup_dir or default_backup_dir
-    
+
     backups = []
-    for backup_file in sorted(backup_dir.glob("mnemosyne_backup_*.db.gz"), reverse=True):
-        meta_file = backup_file.with_suffix('.gz.json')
-        
+    for backup_file in sorted(
+        backup_dir.glob("mnemosyne_backup_*.db.gz"), reverse=True
+    ):
+        meta_file = backup_file.with_suffix(".gz.json")
+
         info = {
             "file": str(backup_file),
             "name": backup_file.name,
             "size": backup_file.stat().st_size,
-            "modified": datetime.fromtimestamp(backup_file.stat().st_mtime).isoformat()
+            "modified": datetime.fromtimestamp(backup_file.stat().st_mtime).isoformat(),
         }
-        
+
         if meta_file.exists():
             with open(meta_file) as f:
                 info["metadata"] = json.load(f)
-        
+
         backups.append(info)
-    
+
     return backups
 
 
 def rotate_backups(backup_dir: Path = None, keep: int = 10) -> Dict:
     """
     Rotate backups, keeping only the most recent N.
-    
+
     Args:
         keep: Number of backups to retain
-        
+
     Returns:
         Dict with rotation results
     """
     _, default_backup_dir, _ = get_default_paths()
     backup_dir = backup_dir or default_backup_dir
-    
+
     backups = sorted(backup_dir.glob("mnemosyne_backup_*.db.gz"))
-    
+
     to_delete = backups[:-keep] if len(backups) > keep else []
     deleted = []
-    
+
     for backup in to_delete:
         # Delete backup and metadata
         backup.unlink()
-        meta = backup.with_suffix('.gz.json')
+        meta = backup.with_suffix(".gz.json")
         if meta.exists():
             meta.unlink()
         deleted.append(backup.name)
-    
+
     return {
         "total_backups": len(backups),
         "kept": keep,
         "deleted": len(deleted),
-        "deleted_files": deleted
+        "deleted_files": deleted,
     }
 
 
 def health_check() -> Dict:
     """
     Comprehensive health check of Mnemosyne system.
-    
+
     Returns:
         Dict with health status of all components
     """
     data_dir, backup_dir, db_path = get_default_paths()
-    
+
     # Check database
     db_exists = db_path.exists()
     db_valid = verify_integrity(db_path) if db_exists else False
-    
+
     # Check backups
-    backups = list(backup_dir.glob("mnemosyne_backup_*.db.gz")) if backup_dir.exists() else []
-    
+    backups = (
+        list(backup_dir.glob("mnemosyne_backup_*.db.gz")) if backup_dir.exists() else []
+    )
+
     return {
         "database": {
             "exists": db_exists,
             "valid": db_valid,
             "path": str(db_path),
-            "message": "Database integrity verified" if db_valid else "Database missing or corrupt"
+            "message": "Database integrity verified"
+            if db_valid
+            else "Database missing or corrupt",
         },
         "backups": {
             "total": len(backups),
             "latest": str(backups[-1]) if backups else None,
-            "directory": str(backup_dir)
+            "directory": str(backup_dir),
         },
-        "status": "healthy" if db_valid else "unhealthy"
+        "status": "healthy" if db_valid else "unhealthy",
     }
 
 
 # CLI interface
 if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) < 2:
-        print("Usage: python -m mnemosyne.dr [backup|restore|emergency|verify|list|health|rotate]")
+        print(
+            "Usage: python -m mnemosyne.dr [backup|restore|emergency|verify|list|health|rotate]"
+        )
         sys.exit(1)
-    
+
     cmd = sys.argv[1]
-    
+
     if cmd == "backup":
         result = create_backup()
         print(json.dumps(result, indent=2))
-    
+
     elif cmd == "restore" and len(sys.argv) > 2:
         result = restore_backup(Path(sys.argv[2]))
         print(json.dumps(result, indent=2))
-    
+
     elif cmd == "emergency":
         result = emergency_restore()
         print(json.dumps(result, indent=2))
-    
+
     elif cmd == "verify":
         valid = verify_integrity()
         print(json.dumps({"valid": valid}))
-    
+
     elif cmd == "list":
         backups = list_backups()
         print(json.dumps(backups, indent=2))
-    
+
     elif cmd == "health":
         status = health_check()
         print(json.dumps(status, indent=2))
-    
+
     elif cmd == "rotate":
         result = rotate_backups()
         print(json.dumps(result, indent=2))
-    
+
     else:
         print(f"Unknown command: {cmd}")
         sys.exit(1)

--- a/tests/test_recovery_paths.py
+++ b/tests/test_recovery_paths.py
@@ -7,9 +7,13 @@ uses. Previously they hardcoded ``~/.mnemosyne/data`` and ignored
 MNEMOSYNE_DATA_DIR / HERMES_HOME, so they operated on (or failed to find) the
 wrong database.
 """
+
 from __future__ import annotations
 
+import json
+import os
 import sqlite3
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -44,7 +48,9 @@ def test_get_default_paths_backup_dir_override(monkeypatch, tmp_path):
     assert backup_dir == tmp_path / "custom_backups"
 
 
-def test_get_default_paths_data_dir_takes_precedence_over_hermes_home(monkeypatch, tmp_path):
+def test_get_default_paths_data_dir_takes_precedence_over_hermes_home(
+    monkeypatch, tmp_path
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "explicit"))
     data_dir, _, db_path = recovery.get_default_paths()
@@ -71,6 +77,7 @@ def test_create_backup_succeeds_with_sqlite_vec_tables(tmp_path):
     conn = sqlite3.connect(str(db_path))
     conn.enable_load_extension(True)
     import sqlite_vec
+
     sqlite_vec.load(conn)
     conn.execute(
         "CREATE VIRTUAL TABLE vec_items USING vec0("
@@ -90,7 +97,842 @@ def test_create_backup_succeeds_with_sqlite_vec_tables(tmp_path):
     assert Path(result["backup_path"]).exists()
     assert result["backup_size"] > 0
     import gzip
+
     with gzip.open(result["backup_path"], "rt") as f:
         dump = f.read()
     assert "vec_items" in dump
     assert "CREATE VIRTUAL TABLE" in dump
+
+
+# ---------------------------------------------------------------------------
+# Task 1 / Wave 1 P0: backup unique filename + fail-closed restore
+# ---------------------------------------------------------------------------
+
+import gzip as _gzip
+
+
+def _make_simple_db(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    conn.executemany("INSERT INTO t VALUES (?, ?)", [(1, "a"), (2, "b")])
+    conn.commit()
+    conn.close()
+
+
+def test_two_rapid_backups_get_unique_filenames(tmp_path):
+    """Two backups created within the same second must not overwrite each
+    other."""
+    db_path = tmp_path / "src.db"
+    _make_simple_db(db_path)
+    bdir = tmp_path / "backups"
+
+    r1 = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+    r2 = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+    assert Path(r1["backup_path"]).name != Path(r2["backup_path"]).name, (
+        "two backups in the same second collided on filename"
+    )
+    assert Path(r1["backup_path"]).exists()
+    assert Path(r2["backup_path"]).exists()
+
+
+def test_restore_rejects_active_wal_sidecar(tmp_path):
+    """A stale -wal sidecar means uncommitted frames would be silently
+    dropped by a main-file replace; restore must refuse."""
+    db_path = tmp_path / "target.db"
+    bdir = tmp_path / "backups"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+    (db_path.parent / (db_path.name + "-wal")).write_bytes(b"\x00" * 64)
+    with pytest.raises(RuntimeError, match="sidecar"):
+        recovery.restore_backup(Path(backup["backup_path"]), db_path)
+
+
+def test_restore_rejects_active_shm_sidecar(tmp_path):
+    db_path = tmp_path / "target.db"
+    bdir = tmp_path / "backups"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+    (db_path.parent / (db_path.name + "-shm")).write_bytes(b"\x00" * 64)
+    with pytest.raises(RuntimeError, match="sidecar"):
+        recovery.restore_backup(Path(backup["backup_path"]), db_path)
+
+
+def test_restore_payload_checksum_mismatch_rejected_and_target_preserved(tmp_path):
+    """Corruption that still decompresses as gzip but changes the dump payload
+    must be caught by the payload checksum and rejected; the target is
+    preserved."""
+    db_path = tmp_path / "target.db"
+    bdir = tmp_path / "backups"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+    backup_path = Path(backup["backup_path"])
+
+    raw = _gzip.decompress(backup_path.read_bytes())
+    corrupted = raw.replace(b"VALUES", b"VALOOS")
+    if corrupted == raw:
+        corrupted = raw.replace(b"CREATE", b"CREAT")
+    backup_path.write_bytes(_gzip.compress(corrupted))
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("INSERT INTO t VALUES (99, 'preserved')")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="checksum"):
+        recovery.restore_backup(backup_path, db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT v FROM t WHERE id = 99").fetchone()
+    conn.close()
+    assert row is not None and row[0] == "preserved", (
+        "target was corrupted by a failed restore"
+    )
+
+
+def test_restore_failed_integrity_preserves_original(tmp_path):
+    """A dump that rebuilds but fails integrity_check must not replace the
+    target."""
+    db_path = tmp_path / "target.db"
+    bdir = tmp_path / "backups"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+    backup_path = Path(backup["backup_path"])
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("INSERT INTO t VALUES (99, 'keepme')")
+    conn.commit()
+    conn.close()
+
+    # Break the dump so it produces an invalid DB but still parses as SQL.
+    raw = _gzip.decompress(backup_path.read_bytes())
+    backup_path.write_bytes(
+        _gzip.compress(raw.replace(b"CREATE TABLE", b"BREAK TABLE"))
+    )
+
+    with pytest.raises(Exception):
+        recovery.restore_backup(backup_path, db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT v FROM t WHERE id = 99").fetchone()
+    conn.close()
+    assert row is not None and row[0] == "keepme"
+
+
+def test_successful_restore_replaces_target_and_preserves_original(tmp_path):
+    db_path = tmp_path / "target.db"
+    bdir = tmp_path / "backups"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+    # Mutate the live target after the backup.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("INSERT INTO t VALUES (42, 'post-backup')")
+    conn.commit()
+    conn.close()
+
+    result = recovery.restore_backup(Path(backup["backup_path"]), db_path)
+
+    assert result["integrity_check"] is True
+    conn = sqlite3.connect(str(db_path))
+    total = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    post_backup_gone = conn.execute("SELECT COUNT(*) FROM t WHERE id = 42").fetchone()[
+        0
+    ]
+    conn.close()
+    assert total == 2, "target not restored to backup contents"
+    assert post_backup_gone == 0
+    preserved = Path(result["preserved_original"])
+    assert preserved.exists(), "original target must be preserved as a sidecar"
+
+
+# ---------------------------------------------------------------------------
+# Task 1 fix round 1: fail-closed metadata, post-replace integrity, held
+# exclusive writer lock, atomic filename allocation, unique staged files,
+# parent-dir fsync, staged cleanup on failure.
+# ---------------------------------------------------------------------------
+
+import threading as _threading
+
+
+def _make_db_simple(db_path):
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    conn.executemany("INSERT INTO t VALUES (?, ?)", [(1, "a"), (2, "b")])
+    conn.commit()
+    conn.close()
+
+
+class TestRestoreMetadataFailClosed:
+    def test_missing_metadata_sidecar_rejected_and_target_preserved(self, tmp_path):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        backup_path = Path(backup["backup_path"])
+        backup_path.with_suffix(".gz.json").unlink()
+
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+        conn = sqlite3.connect(str(target))
+        conn.execute("INSERT INTO t VALUES (99, 'keep')")
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(RuntimeError, match="metadata"):
+            recovery.restore_backup(backup_path, target)
+
+        conn = sqlite3.connect(str(target))
+        row = conn.execute("SELECT v FROM t WHERE id = 99").fetchone()
+        conn.close()
+        assert row and row[0] == "keep"
+
+    def test_malformed_metadata_rejected(self, tmp_path):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        backup_path = Path(backup["backup_path"])
+        backup_path.with_suffix(".gz.json").write_text("{not valid json")
+
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+        with pytest.raises(RuntimeError, match="metadata"):
+            recovery.restore_backup(backup_path, target)
+
+    def test_metadata_without_backup_checksum_rejected(self, tmp_path):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        backup_path = Path(backup["backup_path"])
+        meta_file = backup_path.with_suffix(".gz.json")
+        meta = json.loads(meta_file.read_text())
+        meta.pop("backup_checksum")
+        meta_file.write_text(json.dumps(meta))
+
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+        with pytest.raises(RuntimeError, match="checksum"):
+            recovery.restore_backup(backup_path, target)
+
+
+class TestRestorePostReplaceIntegrityFailure:
+    def test_failed_post_replace_check_restores_original_and_raises(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+        conn = sqlite3.connect(str(target))
+        conn.execute("INSERT INTO t VALUES (77, 'preserved-me')")
+        conn.commit()
+        conn.close()
+
+        # Force the post-replace integrity check to fail.
+        monkeypatch.setattr(recovery, "verify_integrity", lambda p: False)
+
+        with pytest.raises(RuntimeError, match="integrity"):
+            recovery.restore_backup(Path(backup["backup_path"]), target)
+
+        conn = sqlite3.connect(str(target))
+        row = conn.execute("SELECT v FROM t WHERE id = 77").fetchone()
+        ok = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        conn.close()
+        assert row and row[0] == "preserved-me"
+        assert ok == "ok", "original was not restored after post-replace failure"
+
+
+class TestExclusiveWriterLockHeld:
+    def test_competing_writer_cannot_enter_staging_window(self, tmp_path, monkeypatch):
+        """A second connection must be unable to BEGIN IMMEDIATE while a
+        restore holds the writer lock across staging and os.replace."""
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+
+        events = {"locked": False, "competitor_entered": False}
+        ready = _threading.Event()
+        original_replace = os.replace
+
+        def slow_replace(staged, dest):
+            if str(dest) == str(target):
+                events["locked"] = True
+                ready.set()
+                import time
+
+                time.sleep(0.3)
+            return original_replace(staged, dest)
+
+        monkeypatch.setattr("mnemosyne.dr.recovery.os.replace", slow_replace)
+
+        def compete():
+            ready.wait(timeout=2)
+            try:
+                c = sqlite3.connect(str(target), timeout=0.1)
+                c.execute("BEGIN IMMEDIATE")
+                events["competitor_entered"] = True
+                c.execute("ROLLBACK")
+                c.close()
+            except sqlite3.OperationalError:
+                pass
+
+        thread = _threading.Thread(target=compete)
+        thread.start()
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+        thread.join(timeout=3)
+
+        assert events["locked"] is True
+        assert events["competitor_entered"] is False, (
+            "a competing writer entered the staging window despite the lock"
+        )
+
+
+class TestBackupAndStagingRaces:
+    def test_backup_filename_allocation_is_exclusive_under_frozen_clock(
+        self, tmp_path, monkeypatch
+    ):
+        """With the timestamp frozen, four concurrent backups must still get
+        distinct files via exclusive (O_CREAT|O_EXCL) allocation."""
+        db_path = tmp_path / "src.db"
+        _make_db_simple(db_path)
+        bdir = tmp_path / "bk"
+
+        from datetime import datetime as _dt
+
+        frozen = _dt(2026, 1, 1, 0, 0, 0)
+        fake_datetime = type(
+            "D",
+            (),
+            {
+                "now": staticmethod(lambda: frozen),
+                "max": _dt.max,
+                "strftime": _dt.strftime,
+                "fromisoformat": _dt.fromisoformat,
+            },
+        )
+        monkeypatch.setattr(recovery, "datetime", fake_datetime)
+
+        results = []
+        errors = []
+
+        def make():
+            try:
+                results.append(recovery.create_backup(db_path=db_path, backup_dir=bdir))
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=make) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        names = [Path(r["backup_path"]).name for r in results]
+        assert len(names) == len(set(names)), f"filenames collided: {names}"
+        for name in names:
+            assert (bdir / name).stat().st_size > 0
+        assert not errors
+
+    def test_staged_filename_unique_per_invocation_same_target(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        target = tmp_path / "same.db"
+        _make_db_simple(target)
+
+        staged_names = []
+        original_connect = sqlite3.connect
+
+        def spy_connect(connectable, *args, **kwargs):
+            conn = original_connect(connectable, *args, **kwargs)
+            if isinstance(connectable, str) and "restore_staged" in connectable:
+                staged_names.append(Path(connectable).name)
+            return conn
+
+        monkeypatch.setattr("mnemosyne.dr.recovery.sqlite3.connect", spy_connect)
+
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+
+        assert len(staged_names) == 2
+        assert staged_names[0] != staged_names[1], (
+            f"staged filenames collided on same target: {staged_names}"
+        )
+
+    def test_parent_dir_fsynced_after_replace(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+
+        fsynced_dirs = []
+        real_open = os.open
+
+        def spy_open(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if (flags & os.O_DIRECTORY) and str(target.parent) == str(path):
+                fsynced_dirs.append(str(path))
+            return fd
+
+        monkeypatch.setattr("mnemosyne.dr.recovery.os.open", spy_open)
+
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+
+        assert fsynced_dirs, "parent directory was not fsynced after replace"
+
+    def test_staged_file_cleaned_up_on_failure(self, tmp_path):
+        db_path = tmp_path / "src.db"
+        bdir = tmp_path / "bk"
+        _make_db_simple(db_path)
+        backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+        backup_path = Path(backup["backup_path"])
+        target = tmp_path / "target.db"
+        _make_db_simple(target)
+
+        raw = _gzip.decompress(backup_path.read_bytes())
+        backup_path.write_bytes(
+            _gzip.compress(raw.replace(b"CREATE TABLE", b"BREAK TABLE"))
+        )
+
+        with pytest.raises(Exception):
+            recovery.restore_backup(backup_path, target)
+
+        leftovers = list(target.parent.glob("*restore_staged*"))
+        assert leftovers == [], f"staged file not cleaned up: {leftovers}"
+
+
+# ---------------------------------------------------------------------------
+# Security I-1: restore must not execute untrusted dump SQL with SQLite
+# extension loading left enabled. The optional sqlite-vec loader calls
+# enable_load_extension(True); it must be disabled again before any
+# caller runs executescript on backup-provided SQL, and it must stay
+# disabled even when the loader raised ImportError/OperationalError.
+#
+# These tests stub the sqlite_vec module so the leak is exercised
+# deterministically regardless of whether real sqlite_vec is installed
+# (the bug is latent when sqlite_vec is absent because the ImportError
+# fires before enable_load_extension runs).
+# ---------------------------------------------------------------------------
+
+
+def _install_sqlite_vec_stub(monkeypatch, load_side_effect=None):
+    """Install a fake ``sqlite_vec`` module whose ``load(conn)`` mirrors the
+    real extension's behavior: it requires (and enables) extension loading on
+    the connection to register itself.
+
+    If ``load_side_effect`` is given, ``load`` raises it instead, simulating
+    sqlite3.OperationalError from a failed dlopen (another path where the
+    current loader calls enable_load_extension(True) and never restores it).
+    """
+    import sys, types
+
+    fake = types.ModuleType("sqlite_vec")
+
+    def _load(conn):
+        if load_side_effect is not None:
+            raise load_side_effect
+        conn.enable_load_extension(True)  # mirror real sqlite_vec.load
+
+    fake.load = _load
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake)
+    return fake
+
+
+def _assert_load_extension_blocked(conn):
+    """Extension loading must be DISABLED: SQLite rejects load_extension up
+    front with 'not authorized'. If it is still enabled, the call instead
+    reaches the filesystem and fails with 'cannot open shared object' — that
+    is the leak signature.
+    """
+    with pytest.raises(sqlite3.OperationalError) as excinfo:
+        conn.execute("SELECT load_extension('definitely_not_a_real_extension')")
+    assert "not authorized" in str(excinfo.value), (
+        f"extension loading still enabled after _load_sqlite_vec "
+        f"(load_extension was reachable): {excinfo.value!r}"
+    )
+
+
+def test_load_sqlite_vec_disables_extension_loading_after_success(monkeypatch):
+    """RED driver: when sqlite_vec.load() succeeds (and itself enables
+    extension loading to register), _load_sqlite_vec must re-disable
+    extension loading before returning.
+
+    Pre-fix the call to enable_load_extension(True) inside the loader is never
+    reverted, so load_extension remains callable afterward.
+    """
+    _install_sqlite_vec_stub(monkeypatch)
+    conn = sqlite3.connect(":memory:")
+    recovery._load_sqlite_vec(conn)
+    _assert_load_extension_blocked(conn)
+
+
+def test_load_sqlite_vec_disables_extension_loading_after_operational_error(
+    monkeypatch,
+):
+    """If sqlite_vec.load() itself raises OperationalError (e.g. a failed
+    dlopen on a present-but-broken build), enable_load_extension(True) has
+    already run and must still be re-disabled.
+    """
+    _install_sqlite_vec_stub(
+        monkeypatch, load_side_effect=sqlite3.OperationalError("dlopen failed")
+    )
+    conn = sqlite3.connect(":memory:")
+    recovery._load_sqlite_vec(conn)
+    _assert_load_extension_blocked(conn)
+
+
+def test_load_sqlite_vec_disables_extension_loading_when_absent(monkeypatch):
+    """When sqlite-vec is NOT installed, _load_sqlite_vec swallows the
+    ImportError and must leave extension loading disabled. (Today this passes
+    incidentally because the ImportError fires before the toggle; the stub
+    makes the assertion load-bearing for the future.)
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "sqlite_vec", None)
+    conn = sqlite3.connect(":memory:")
+    recovery._load_sqlite_vec(conn)  # must not raise
+    _assert_load_extension_blocked(conn)
+
+
+def test_restore_backup_rejects_load_extension_in_dump(tmp_path, monkeypatch):
+    """End-to-end: a tampered-but-checksum-valid backup whose dump SQL invokes
+    load_extension must NOT execute that call. The staged-restore connection
+    must have extension loading disabled when executescript runs.
+
+    We stub sqlite_vec so the leak is deterministic, craft a backup whose dump
+    embeds ``SELECT load_extension(...)``, and recompute both checksums so it
+    passes restore's integrity gate — isolating the extension-loading vector
+    from the checksum gate (checksums are integrity, not authenticity).
+    """
+    import gzip as _gz
+
+    _install_sqlite_vec_stub(monkeypatch)
+
+    db_path = tmp_path / "src.db"
+    bdir = tmp_path / "bk"
+    _make_simple_db(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+    backup_path = Path(backup["backup_path"])
+    meta_path = backup_path.with_suffix(".gz.json")
+
+    raw = _gz.decompress(backup_path.read_bytes())
+    malicious = raw + b"\nSELECT load_extension('evil_extension_payload');\n"
+    backup_path.write_bytes(_gz.compress(malicious))
+
+    new_backup_checksum = hashlib.sha256(backup_path.read_bytes()).hexdigest()[:16]
+    new_dump_checksum = hashlib.sha256(malicious).hexdigest()
+    meta = json.loads(meta_path.read_text())
+    meta["backup_checksum"] = new_backup_checksum
+    meta["dump_checksum"] = new_dump_checksum
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+    target = tmp_path / "target.db"
+    _make_simple_db(target)
+
+    with pytest.raises(sqlite3.OperationalError) as excinfo:
+        recovery.restore_backup(backup_path, target)
+    assert "not authorized" in str(excinfo.value), (
+        f"untrusted dump SQL reached load_extension during restore "
+        f"(extension loading was enabled on the staged connection): "
+        f"{excinfo.value!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 9: re-acquire the writer lock on the replacement inode after
+# os.replace(). A BEGIN IMMEDIATE lock binds to the inode opened at connect
+# time; after os.replace the path resolves to a NEW inode that the held lock
+# does not cover. These tests prove a competing writer (a separate process
+# with busy_timeout=0) cannot enter the post-replace verify or rollback
+# window, that re-acquisition failure is fail-closed and visible, and that
+# rollback remains an in-place copy (inode-stable) so the new-inode lock
+# covers it.
+#
+# Competitors run in a SEPARATE PROCESS (multiprocessing) coordinated by
+# multiprocessing.Event / Queue — no arbitrary sleeps. This catches a lock
+# regression that same-process threads would not on a POSIX-fcntl-lock build.
+# ---------------------------------------------------------------------------
+
+import multiprocessing as _mp
+import shutil as _shutil
+
+
+def _backup_and_target(tmp_path):
+    """Build a valid backup and an existing target with a distinguishing row."""
+    db_path = tmp_path / "src.db"
+    bdir = tmp_path / "bk"
+    _make_db_simple(db_path)
+    backup = recovery.create_backup(db_path=db_path, backup_dir=bdir)
+
+    target = tmp_path / "target.db"
+    _make_db_simple(target)
+    conn = sqlite3.connect(str(target))
+    conn.execute("INSERT INTO t VALUES (777, 'target-original')")
+    conn.commit()
+    conn.close()
+    return backup, target
+
+
+def _competitor_worker(target_str, enter_event, allow_event, result_queue):
+    """Separate-process competitor: wait for enter_event, then try to acquire
+    a writer lock with busy_timeout=0 and insert a row. Reports (entered, err)
+    via result_queue."""
+    try:
+        enter_event.wait(timeout=10)
+        conn = sqlite3.connect(target_str, timeout=0)
+        conn.execute("PRAGMA busy_timeout=0")
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute("INSERT INTO t VALUES (8888, 'competitor')")
+        conn.commit()
+        conn.close()
+        result_queue.put((True, None))
+    except sqlite3.OperationalError as exc:
+        result_queue.put((False, str(exc)))
+    except Exception as exc:  # pragma: no cover - defensive
+        result_queue.put((False, repr(exc)))
+
+
+def test_competing_writer_cannot_enter_post_replace_verify_window(
+    tmp_path, monkeypatch
+):
+    """A separate-process writer must NOT be able to BEGIN IMMEDIATE on the
+    target while post-replace integrity verification runs. Before the fix the
+    held lock belongs to the OLD inode (replaced away), so the competitor
+    succeeds."""
+    backup, target = _backup_and_target(tmp_path)
+
+    verify_entered = _threading.Event()
+    allow_verify = _threading.Event()
+
+    def gated_verify(path):
+        verify_entered.set()
+        allow_verify.wait(timeout=10)
+        return True
+
+    monkeypatch.setattr(recovery, "verify_integrity", gated_verify)
+
+    # Use a multiprocessing Event/Queue visible to the child process.
+    ctx = _mp.get_context("spawn")
+    m_enter = ctx.Event()
+    m_allow = ctx.Event()
+    m_queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_competitor_worker,
+        args=(str(target), m_enter, m_allow, m_queue),
+    )
+    proc.start()
+
+    # Bridge the in-process threading.Event to the multiprocessing.Event so
+    # the competitor is released exactly when verify_integrity is entered.
+    def gated_verify_mp(path):
+        verify_entered.set()
+        m_enter.set()
+        allow_verify.wait(timeout=10)
+        return True
+
+    monkeypatch.setattr(recovery, "verify_integrity", gated_verify_mp)
+
+    try:
+        # Run restore in a thread so we can handshake events.
+        result_holder = {"exc": None}
+
+        def do_restore():
+            try:
+                recovery.restore_backup(Path(backup["backup_path"]), target)
+            except Exception as exc:
+                result_holder["exc"] = exc
+
+        t = _threading.Thread(target=do_restore)
+        t.start()
+        # Wait until verify is entered (competitor now released).
+        verify_entered.wait(timeout=10)
+        # Give the competitor a moment to attempt (it will block/fail under
+        # the fix; under the bug it commits instantly). Poll the queue with a
+        # short timeout instead of sleeping.
+        competitor_result = m_queue.get(timeout=5)
+        allow_verify.set()
+        t.join(timeout=10)
+
+        assert result_holder["exc"] is None, (
+            f"restore raised unexpectedly: {result_holder['exc']!r}"
+        )
+        entered, err = competitor_result
+        assert entered is False, (
+            "competing writer entered the post-replace VERIFY window and "
+            f"committed a row (err={err})"
+        )
+        assert err is not None and "locked" in err.lower(), (
+            f"expected 'database is locked', got: {err}"
+        )
+    finally:
+        proc.join(timeout=5)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=5)
+
+
+def test_competing_writer_cannot_enter_post_replace_rollback_window(
+    tmp_path, monkeypatch
+):
+    """When post-replace verify fails and the rollback copy runs, a separate-
+    process writer must NOT be able to BEGIN IMMEDIATE on the target. Before
+    the fix the new inode is unlocked during rollback."""
+    backup, target = _backup_and_target(tmp_path)
+    original_bytes = target.read_bytes()
+
+    monkeypatch.setattr(recovery, "verify_integrity", lambda p: False)
+
+    ctx = _mp.get_context("spawn")
+    m_enter = ctx.Event()
+    m_allow = ctx.Event()
+    m_queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_competitor_worker,
+        args=(str(target), m_enter, m_allow, m_queue),
+    )
+    proc.start()
+
+    rollback_entered = _threading.Event()
+    allow_rollback = _threading.Event()
+    real_copy2 = _shutil.copy2
+
+    def gated_copy2(src, dst, *args, **kwargs):
+        # Only the rollback direction: preserved -> target.
+        if str(src).endswith(".restore_preserved") and str(dst) == str(target):
+            rollback_entered.set()
+            m_enter.set()
+            allow_rollback.wait(timeout=10)
+        return real_copy2(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr("mnemosyne.dr.recovery.shutil.copy2", gated_copy2)
+
+    try:
+        result_holder = {"exc": None}
+
+        def do_restore():
+            try:
+                recovery.restore_backup(Path(backup["backup_path"]), target)
+            except Exception as exc:
+                result_holder["exc"] = exc
+
+        t = _threading.Thread(target=do_restore)
+        t.start()
+        rollback_entered.wait(timeout=10)
+        competitor_result = m_queue.get(timeout=5)
+        allow_rollback.set()
+        t.join(timeout=10)
+
+        assert result_holder["exc"] is not None, (
+            "restore did not raise after forced post-replace integrity failure"
+        )
+        entered, err = competitor_result
+        assert entered is False, (
+            "competing writer entered the post-replace ROLLBACK window and "
+            f"committed a row (err={err})"
+        )
+        assert err is not None and "locked" in err.lower(), (
+            f"expected 'database is locked', got: {err}"
+        )
+        # Rollback restored original bytes in place.
+        assert target.read_bytes() == original_bytes, (
+            "target bytes differ from original after rollback"
+        )
+    finally:
+        proc.join(timeout=5)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=5)
+
+
+def test_restore_backup_post_replace_reacquire_failure_is_visible_and_valid(
+    tmp_path, monkeypatch
+):
+    """If the SECOND (post-replace) writer-lock acquisition fails, the restore
+    must raise visibly (fail-closed) and never claim success. The target holds
+    the staged image (verified + fsynced before replace). This test fakes the
+    failure; the real-race contract is a visible failure + retained preserved
+    original, not a proof that a competitor could not have changed the target.
+    """
+    backup, target = _backup_and_target(tmp_path)
+
+    original_acquire = recovery._acquire_writer_lock
+    call_count = {"n": 0}
+
+    def fail_second_acquire(db_path):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise sqlite3.OperationalError("database is locked")
+        return original_acquire(db_path)
+
+    monkeypatch.setattr(recovery, "_acquire_writer_lock", fail_second_acquire)
+
+    with pytest.raises(Exception) as excinfo:
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+
+    # Fail-closed: a visible error, not a silent success.
+    assert (
+        "locked" in str(excinfo.value).lower()
+        or "restore" in str(excinfo.value).lower()
+    ), f"unexpected error shape: {excinfo.value!r}"
+
+    # The staged image at the path is a valid database (it was verified and
+    # fsynced before the replace). Pinned only because this test fakes the
+    # failure with no real competitor.
+    conn = sqlite3.connect(str(target))
+    ok = conn.execute("PRAGMA integrity_check").fetchone()[0]
+    conn.close()
+    assert ok == "ok", "staged image left at target was not a valid database"
+
+    # The preserved original is retained (recovery never cleans it).
+    preserved = target.with_name(target.name + ".restore_preserved")
+    assert preserved.exists(), "preserved original was lost on reacquire failure"
+
+
+def test_restore_backup_rollback_copy_keeps_target_inode(tmp_path, monkeypatch):
+    """The rollback copy (shutil.copy2 preserved -> target) must be in-place:
+    it must NOT replace the target inode. This pins the assumption that lets
+    the replacement-inode lock cover the rollback copy."""
+    backup, target = _backup_and_target(tmp_path)
+
+    monkeypatch.setattr(recovery, "verify_integrity", lambda p: False)
+
+    inodes = {}
+    real_copy2 = _shutil.copy2
+
+    def inode_tracking_copy2(src, dst, *args, **kwargs):
+        if str(src).endswith(".restore_preserved") and str(dst) == str(target):
+            inodes["before"] = os.stat(str(target)).st_ino
+        result = real_copy2(src, dst, *args, **kwargs)
+        if str(src).endswith(".restore_preserved") and str(dst) == str(target):
+            inodes["after"] = os.stat(str(target)).st_ino
+        return result
+
+    monkeypatch.setattr("mnemosyne.dr.recovery.shutil.copy2", inode_tracking_copy2)
+
+    with pytest.raises(Exception):
+        recovery.restore_backup(Path(backup["backup_path"]), target)
+
+    assert "before" in inodes and "after" in inodes, (
+        "rollback copy was not observed (inode tracking did not fire)"
+    )
+    assert inodes["before"] == inodes["after"], (
+        f"rollback copy changed the target inode ({inodes['before']} -> "
+        f"{inodes['after']}); the new-inode lock would NOT cover the rollback"
+    )


### PR DESCRIPTION
Split from bundled #788 per dplush feedback. Focused backup/restore hardening and regression matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR hardens Mnemosyne’s local backup and restore paths.

- Backups use configured paths, unique names, SQLite online backups, chunked SHA-256 checksums, atomic publication, and failure cleanup.
- Restore validates metadata and checksums, rejects WAL/SHM sidecars, and denies `SQLITE_ATTACH`.
- Restore stages files, preserves originals, verifies integrity, fsyncs changes, rolls back after post-replacement failure, and reacquires writer exclusion after inode replacement.
- Recovery handles malformed metadata, emergency-restore attempt counts, `rotate_backups(keep=0)`, concurrent deletion, and optional sqlite-vec support.
- The CLI requires an explicit restore path.
- Regression tests cover staging visibility, locking, cleanup, atomic replacement, integrity checks, extension handling, and environment-based paths.

## Architectural impact

- **Local-first guarantees:** Strengthened through fail-closed validation, atomic replacement, rollback, cleanup, and fsync handling.
- **Privacy posture:** Improved. Restore blocks database attachment and disables extension loading after sqlite-vec setup. No backup encryption was added.
- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval, consolidation, veracity, and sync:** No changes.
- **Agent integration:** No Hermes or MCP changes. The CLI now requires an explicit restore path.
- **Benchmark methodology:** No changes.
- **Maintainability:** Improved through explicit recovery invariants and regression coverage.

The right call is to isolate recovery hardening and enforce fail-closed restore behavior. Reported verification includes 30 recovery tests, 40 related tests, clean Ruff checks, and a clean diff check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->