### PR TITLE
fix(hygiene): isolate transaction behavior

### DIFF
--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -674,6 +674,14 @@ def clean_noise(
         for c in candidates:
             effective_action = action if action != "keep" else c.suggested_action
 
+            # Isolate each candidate in its own savepoint so a failure on one
+            # candidate (partial mutation, audit-log write error, etc.) rolls
+            # back ONLY that candidate's staged changes. Without this, a
+            # mid-candidate raise leaves the partial mutation staged in the
+            # shared transaction and committed at the end alongside every
+            # other candidate, producing a half-applied row that the audit
+            # log does not describe.
+            cursor.execute("SAVEPOINT hygiene_candidate")
             try:
                 # Fetch original content + metadata for audit log
                 cursor.execute(
@@ -682,19 +690,26 @@ def clean_noise(
                 )
                 row = cursor.fetchone()
                 if row is None:
+                    cursor.execute("ROLLBACK TO hygiene_candidate")
+                    cursor.execute("RELEASE hygiene_candidate")
                     result.errors.append(f"Row not found: {c.table_name}:{c.memory_id}")
                     continue
 
                 original_content = row["content"] or ""
                 original_metadata = row["metadata_json"] or "{}"
 
+                # Stage the mutation and audit write, then bump counters ONLY
+                # after the savepoint releases successfully. Previously the
+                # counters were incremented before the audit INSERT; an audit
+                # failure rolled back the row mutation (savepoint) but left a
+                # success count that did not match the committed state.
+                committed_action = None
                 if effective_action == "delete":
                     cursor.execute(
                         f"DELETE FROM {c.table_name} WHERE id = ?",
                         (c.memory_id,),
                     )
-                    result.deleted += 1
-                    log_action = "deleted"
+                    committed_action = "deleted"
                 elif effective_action == "archive":
                     # Archive = set importance to 0 and add metadata flag.
                     # This decays the row out of active retrieval without
@@ -717,8 +732,7 @@ def clean_noise(
                         f"UPDATE {c.table_name} SET importance = 0, metadata_json = ? WHERE id = ?",
                         (json.dumps(meta), c.memory_id),
                     )
-                    result.archived += 1
-                    log_action = "archived"
+                    committed_action = "archived"
                 elif effective_action == "flag":
                     # Flag = mark in metadata for operator review. No content change.
                     meta = json.loads(original_metadata) if original_metadata else {}
@@ -728,11 +742,9 @@ def clean_noise(
                         f"UPDATE {c.table_name} SET metadata_json = ? WHERE id = ?",
                         (json.dumps(meta), c.memory_id),
                     )
-                    result.flagged += 1
-                    log_action = "flagged"
+                    committed_action = "flagged"
                 else:
-                    result.kept += 1
-                    log_action = "kept"
+                    committed_action = "kept"
 
                 # Write audit log entry
                 cursor.execute(
@@ -744,7 +756,7 @@ def clean_noise(
                     (
                         c.memory_id,
                         c.table_name,
-                        log_action,
+                        committed_action,
                         json.dumps(c.noise_reasons),
                         c.noise_score,
                         json.dumps(c.secret_flags),
@@ -754,17 +766,38 @@ def clean_noise(
                         None,  # session_id not tracked at log level
                     ),
                 )
+                cursor.execute("RELEASE hygiene_candidate")
+                # Counters are only truthful once the savepoint has released.
+                if committed_action == "deleted":
+                    result.deleted += 1
+                elif committed_action == "archived":
+                    result.archived += 1
+                elif committed_action == "flagged":
+                    result.flagged += 1
+                else:
+                    result.kept += 1
                 result.log_entries += 1
 
-            except Exception as e:
-                result.errors.append(f"Error processing {c.table_name}:{c.memory_id}: {e}")
-                logger.warning("Hygiene cleanup error for %s:%s: %s",
-                               c.table_name, c.memory_id, e)
+            except Exception:
+                try:
+                    cursor.execute("ROLLBACK TO hygiene_candidate")
+                    cursor.execute("RELEASE hygiene_candidate")
+                except sqlite3.Error:
+                    logger.warning("hygiene_savepoint_rollback_failed: %s:%s",
+                                   c.table_name, c.memory_id)
+                # Structural, content-free error: identify which candidate
+                # failed without leaking raw exception text or a traceback.
+                # table_name:memory_id are candidate references (not content),
+                # required by the cleanup status contract so operators can
+                # see which candidate to retry.
+                result.errors.append(f"hygiene_candidate_failed: {c.table_name}:{c.memory_id}")
+                logger.warning("hygiene_candidate_failed: %s:%s",
+                               c.table_name, c.memory_id)
 
         conn.commit()
-    except Exception as e:
+    except Exception:
         conn.rollback()
-        result.errors.append(f"Transaction failed: {e}")
+        result.errors.append("hygiene_transaction_failed")
     finally:
         conn.close()
 
@@ -832,6 +865,16 @@ def restore_archived(
                 continue
             current_meta = row["metadata_json"] or "{}"
             meta = json.loads(current_meta)
+
+            # Idempotency guard: only restore rows that are still archived.
+            # The audit log is append-only, so a second restore_archived()
+            # call would otherwise re-select already-restored entries, find
+            # no _original_importance (it was popped on the first restore),
+            # fall back to 0.5, and overwrite the correct importance value.
+            # Skipping rows whose _archived flag is gone makes repeat calls a
+            # safe no-op.
+            if not meta.get("_archived"):
+                continue
 
             # Use the preserved _original_importance from metadata if
             # available; fall back to 0.5 for entries archived before

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -479,19 +479,18 @@ def test_doctor_cli_single_output_failure_preserves_target_and_cleans_temps(
             return real_replace(source, destination)
 
         monkeypatch.setattr(doctor.os, "replace", fail_replace)
-        error = "simulated CLI single-target replace failure"
     else:
 
         def fail_fsync(_descriptor):
             raise OSError("simulated CLI single-target fsync failure")
 
         monkeypatch.setattr(doctor.os, "fsync", fail_fsync)
-        error = "simulated CLI single-target fsync failure"
 
     with pytest.raises(SystemExit) as raised:
         cli.cmd_doctor(["--db", str(db_path), "--format", output_format, output_flag, str(target)])
 
     assert raised.value.code == 1
-    assert error in capsys.readouterr().err
+    assert "Error: doctor_report_failed" in capsys.readouterr().err
     assert target.read_text() == previous
     assert not list(tmp_path.glob(".doctor-*"))
+

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -807,14 +807,14 @@ class TestAuditNoise:
         assert capsys.readouterr().err == ""
 
     @pytest.mark.parametrize(
-        ("command_args", "function_name"),
+        ("command_args", "function_name", "expected_code"),
         [
-            (["audit"], "audit_noise"),
-            (["status"], "hygiene_status"),
+            (["audit"], "audit_noise", "hygiene_audit_failed"),
+            (["status"], "hygiene_status", "hygiene_status_failed"),
         ],
     )
     def test_cmd_hygiene_read_commands_close_connection_after_hygiene_error(
-        self, monkeypatch, tmp_path, capsys, command_args, function_name
+        self, monkeypatch, tmp_path, capsys, command_args, function_name, expected_code
     ):
         db_path = tmp_path / "mnemosyne.db"
         sqlite3.connect(db_path).close()
@@ -840,11 +840,19 @@ class TestAuditNoise:
         assert connection is not None
         with pytest.raises(sqlite3.ProgrammingError):
             connection.execute("SELECT 1")
-        assert "hygiene read failed" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert f"Error: {expected_code}" in err
+        assert "hygiene read failed" not in err
 
-    @pytest.mark.parametrize("command_args", [["audit"], ["status"]])
+    @pytest.mark.parametrize(
+        ("command_args", "expected_code"),
+        [
+            (["audit"], "hygiene_audit_failed"),
+            (["status"], "hygiene_status_failed"),
+        ],
+    )
     def test_cmd_hygiene_read_commands_report_readonly_open_errors(
-        self, monkeypatch, tmp_path, capsys, command_args
+        self, monkeypatch, tmp_path, capsys, command_args, expected_code
     ):
         db_path = tmp_path / "mnemosyne.db"
         sqlite3.connect(db_path).close()
@@ -858,7 +866,9 @@ class TestAuditNoise:
         with pytest.raises(SystemExit):
             cmd_hygiene(command_args)
 
-        assert "readonly connection failed" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert f"Error: {expected_code}" in err
+        assert "readonly connection failed" not in err
 
     def test_noise_summary_is_pii_safe(self, temp_db):
         db_path, beam = temp_db
@@ -1150,3 +1160,307 @@ def test_hygiene_suite_does_not_leak_config_into_subagent_provider(tmp_path, mon
     provider.initialize("hygiene-followup", agent_context="subagent")
 
     assert provider._beam is None
+
+
+# ---------------------------------------------------------------------------
+# Task 1 / Wave 1 P0: per-candidate savepoint isolation + idempotent restore
+# ---------------------------------------------------------------------------
+
+
+class TestHygieneSavepointIsolation:
+    """Hygiene mutation, auxiliary cleanup, and audit writes must be isolated
+    by a per-candidate savepoint so one bad candidate does not partially
+    mutate another."""
+
+    def test_bad_candidate_partial_mutation_rolled_back_good_candidate_preserved(self, temp_db):
+        db_path, beam = temp_db
+        _insert_row(beam, "working_memory", "good", "good content", importance=0.7)
+        _insert_row(beam, "working_memory", "bad", "bad content", importance=0.7)
+        # A non-JSON-serializable noise_reason makes json.dumps raise during
+        # bad's audit-log INSERT, AFTER bad's DELETE has staged.
+        candidates = [
+            NoiseCandidate(
+                memory_id="good", table_name="working_memory",
+                content_preview="", noise_score=0.8,
+                noise_reasons=["x"], suggested_action="delete",
+            ),
+            NoiseCandidate(
+                memory_id="bad", table_name="working_memory",
+                content_preview="", noise_score=0.8,
+                noise_reasons=[object()],  # not JSON-serializable
+                suggested_action="delete",
+            ),
+        ]
+        result = clean_noise(db_path, candidates, action="delete", confirm=True, dry_run=False)
+
+        conn = sqlite3.connect(str(db_path))
+        good = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE id = 'good'"
+        ).fetchone()[0]
+        bad = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE id = 'bad'"
+        ).fetchone()[0]
+        good_log = conn.execute(
+            "SELECT COUNT(*) FROM hygiene_audit_log WHERE memory_id = 'good'"
+        ).fetchone()[0]
+        bad_log = conn.execute(
+            "SELECT COUNT(*) FROM hygiene_audit_log WHERE memory_id = 'bad'"
+        ).fetchone()[0]
+        conn.close()
+
+        assert good == 0, "good candidate should be deleted"
+        assert bad == 1, (
+            "bad candidate must survive — its partial DELETE should have been "
+            "rolled back by the per-candidate savepoint"
+        )
+        assert good_log == 1, "good candidate audit entry committed"
+        assert bad_log == 0, "bad candidate audit entry must not have committed"
+        assert any("bad" in e for e in result.errors)
+
+
+class TestHygieneRestoreIdempotent:
+    """restore_archived() must be idempotent — calling it twice must not
+    corrupt the restored importance value."""
+
+    def test_restore_twice_does_not_corrupt_importance(self, temp_db):
+        db_path, beam = temp_db
+        _insert_row(beam, "working_memory", "n1", "heartbeat", importance=0.8,
+                    metadata={"original": "data"})
+        candidates = [NoiseCandidate(
+            memory_id="n1", table_name="working_memory",
+            content_preview="heartbeat", noise_score=0.6,
+            noise_reasons=["trivial"], suggested_action="archive",
+        )]
+        clean_noise(db_path, candidates, action="archive", confirm=True, dry_run=False)
+
+        first = restore_archived(db_path)
+        restore_archived(db_path)  # idempotent: must not raise or duplicate
+
+        assert first >= 1, "first restore should recover the archived row"
+        conn = sqlite3.connect(str(db_path))
+        importance, metadata_json = conn.execute(
+            "SELECT importance, metadata_json FROM working_memory WHERE id = 'n1'"
+        ).fetchone()
+        conn.close()
+        assert importance == 0.8, (
+            "second restore overwrote the restored importance — restore is not "
+            "idempotent"
+        )
+        meta = json.loads(metadata_json)
+        assert "_archived" not in meta
+        assert "_original_importance" not in meta
+        assert meta.get("original") == "data"
+
+
+# ---------------------------------------------------------------------------
+# Task 1 fix round 1: transactional hygiene counters
+# ---------------------------------------------------------------------------
+
+
+class TestHygieneTransactionalCounters:
+    """result.deleted/archived/flagged must reflect committed savepoint state,
+    not pre-rollback optimism."""
+
+    def test_failed_audit_rollback_keeps_counters_truthful(self, tmp_path):
+        db_path = tmp_path / "txcount.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE working_memory ("
+            "id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT, "
+            "session_id TEXT, importance REAL, metadata_json TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE hygiene_audit_log ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, memory_id TEXT, table_name TEXT, "
+            "action TEXT, reason TEXT, noise_score REAL, secret_flags TEXT, "
+            "original_content_preview TEXT, original_metadata TEXT, "
+            "timestamp TEXT, session_id TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('good','g','s','t','s',0.7,'{}')"
+        )
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('bad','b','s','t','s',0.7,'{}')"
+        )
+        conn.commit()
+        conn.close()
+
+        candidates = [
+            NoiseCandidate(
+                memory_id="good", table_name="working_memory",
+                content_preview="", noise_score=0.8,
+                noise_reasons=["x"], suggested_action="delete",
+            ),
+            NoiseCandidate(
+                memory_id="bad", table_name="working_memory",
+                content_preview="", noise_score=0.8,
+                # object() is not JSON-serializable: the audit INSERT for this
+                # candidate fails after its DELETE has staged.
+                noise_reasons=[object()],
+                suggested_action="delete",
+            ),
+        ]
+        result = clean_noise(db_path, candidates, action="delete", confirm=True, dry_run=False)
+
+        conn = sqlite3.connect(str(db_path))
+        good = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE id = 'good'"
+        ).fetchone()[0]
+        bad = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE id = 'bad'"
+        ).fetchone()[0]
+        conn.close()
+
+        assert good == 0, "good candidate should be deleted"
+        assert bad == 1, "bad candidate must survive (savepoint rollback)"
+        assert result.deleted == 1, (
+            f"deleted count {result.deleted} does not match committed state (1)"
+        )
+        assert any("bad" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Task 29: per-candidate error path must not leak raw exception/traceback
+# ---------------------------------------------------------------------------
+
+
+class TestHygieneCleanNoLeak:
+    """The clean_noise() per-candidate failure path must produce structural,
+    content-free errors — no raw exception text, no traceback, no content-derived
+    identifier that is not essential to the cleanup status contract."""
+
+    @staticmethod
+    def _failing_candidate():
+        """A candidate whose audit-log write raises with a unique marker.
+
+        ``noise_reasons`` holds a non-JSON-serializable instance of a uniquely
+        named class; ``json.dumps`` during the audit-log INSERT raises a
+        ``TypeError`` whose ``str()`` contains the marker class name.
+        """
+
+        class MarkerHygieneLeakProbeXyz9:  # unique marker baked into the type name
+            pass
+
+        return NoiseCandidate(
+            memory_id="leaky",
+            table_name="working_memory",
+            content_preview="",
+            noise_score=0.8,
+            noise_reasons=[MarkerHygieneLeakProbeXyz9()],
+            suggested_action="delete",
+        )
+
+    def test_per_candidate_error_excludes_marker_traceback_and_remains_an_error(
+        self, tmp_path, caplog
+    ):
+        db_path = tmp_path / "leak.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE working_memory ("
+            "id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT, "
+            "session_id TEXT, importance REAL, metadata_json TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('leaky','c','s','t','s',0.7,'{}')"
+        )
+        conn.commit()
+        conn.close()
+
+        candidate = self._failing_candidate()
+        marker = type(candidate.noise_reasons[0]).__name__
+
+        with caplog.at_level("WARNING", logger="mnemosyne.core.hygiene"):
+            result = clean_noise(
+                db_path, [candidate], action="delete", confirm=True, dry_run=False
+            )
+
+        # The result must still be an error (not silently successful).
+        assert result.errors, "failed candidate must still surface an error"
+
+        # A static, structural error code must be visible to the CLI surface.
+        assert any(
+            "hygiene_candidate_failed" in err or "candidate_failed" in err
+            for err in result.errors
+        ), f"static error code missing from result.errors: {result.errors}"
+
+        # The unique marker (raw exception text) must not reach result.errors.
+        assert not any(marker in err for err in result.errors), (
+            f"raw exception marker leaked into result.errors: {result.errors}"
+        )
+
+        # No traceback must reach the captured log output.
+        log_text = caplog.text
+        assert "Traceback" not in log_text, (
+            f"traceback leaked into log output:\n{log_text}"
+        )
+        assert marker not in log_text, (
+            f"raw exception marker leaked into log output:\n{log_text}"
+        )
+
+        # Good-candidate behavior remains intact: the row survives because the
+        # per-candidate savepoint rolled back the partial DELETE.
+        verify = sqlite3.connect(str(db_path))
+        try:
+            surviving = verify.execute(
+                "SELECT COUNT(*) FROM working_memory WHERE id = 'leaky'"
+            ).fetchone()[0]
+        finally:
+            verify.close()
+        assert surviving == 1, "failed candidate row must survive savepoint rollback"
+
+    def test_transaction_failure_excludes_raw_exception_text(
+        self, tmp_path, monkeypatch
+    ):
+        """The outer transaction-failure path must also be content-free."""
+        db_path = tmp_path / "txleak.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE working_memory ("
+            "id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT, "
+            "session_id TEXT, importance REAL, metadata_json TEXT)"
+        )
+        conn.execute("INSERT INTO working_memory VALUES ('k','c','s','t','s',0.7,'{}')")
+        conn.commit()
+        conn.close()
+
+        marker = "MarkerTxnLeakProbeZzz1"
+        candidate = NoiseCandidate(
+            memory_id="k",
+            table_name="working_memory",
+            content_preview="",
+            noise_score=0.8,
+            noise_reasons=["x"],
+            suggested_action="delete",
+        )
+
+        # Wrap sqlite3.connect so the connection's commit() raises with a
+        # marker-bearing message, forcing the outer transaction-failure path.
+        original_connect = sqlite3.connect
+
+        class _FailingCommitConnection:
+            def __init__(self, real):
+                self._real = real
+
+            def commit(self):
+                raise sqlite3.OperationalError(marker + ": synthetic commit failure")
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+        def connect_failing_commit(*a, **kw):
+            return _FailingCommitConnection(original_connect(*a, **kw))
+
+        monkeypatch.setattr(hygiene_module.sqlite3, "connect", connect_failing_commit)
+
+        result = clean_noise(
+            db_path, [candidate], action="delete", confirm=True, dry_run=False
+        )
+
+        assert result.errors, "transaction failure must surface an error"
+        assert any(
+            "hygiene_transaction_failed" in err or "transaction_failed" in err
+            for err in result.errors
+        ), f"static error code missing: {result.errors}"
+        assert not any(marker in err for err in result.errors), (
+            f"raw exception marker leaked into transaction error: {result.errors}"
+        )


### PR DESCRIPTION
Split from bundled #788 per dplush feedback. Focused hygiene transaction behavior and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Isolates each hygiene candidate operation in a savepoint.
- Rolls back only failed candidates.
- Aborts the transaction and resets counters when recovery or final commit fails.
- Validates candidate table names before mutation.
- Records structured, content-free errors and committed action values.
- Makes `restore_archived` idempotent.
- Adds regression coverage for candidate and transaction failures.
- Updates CLI tests for stable error codes and suppressed exception details.

## Architecture impact

- **Core memory architecture:** Improves hygiene transaction isolation. It does not change the working, episodic, or BEAM tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system:** Improves audit accuracy and failure reporting. It does not change veracity rules.
- **Privacy posture:** Reduces exception-detail leakage in hygiene errors, logs, and CLI output.
- **Local-first guarantees:** Preserved. The change remains local and transactional. No sync or remote dependency changes.
- **Agent integration:** Updates CLI failure handling. No changes to Hermes or MCP interfaces.
- **Sync layer:** No changes.
- **Benchmark methodology:** No changes.
- **Maintainability:** Savepoint isolation, early validation, truthful counters, structured errors, idempotent restoration, and regression tests clarify failure behavior.

Per-candidate savepoints are the right call. They preserve successful hygiene work while maintaining transaction integrity. Nothing in this change erodes the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->