### PR TITLE
feat(recall): add scoped metadata projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **Recall metadata can be projected explicitly without expanding default results.** `recall(..., metadata_keys=[...])` bulk-loads selected top-level metadata keys only for rows that passed that recall call's filters, with at most one query per physical memory tier. It is opt-in, skips synthetic rows, limits pages to 500 rows and projections to 32 keys / 16 KiB per result, and never exposes unrequested metadata.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 
   The stack is additive throughout. Two sidecar tables, `media_assets` and `media_moments`, are created `IF NOT EXISTS` by their own store when a bank is opened, so existing databases acquire them with no migration step and no change to any existing table. No new package dependency is introduced.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -137,7 +137,19 @@ results = mem.recall(
 )
 ```
 
-Returns a list of dicts with keys: `id`, `content`, `score`, `source`, `timestamp`, `importance`, `scope`, `metadata`.
+Returns compact result dicts with ranking, source, lifecycle and scope fields. Stored `metadata_json` is not included by default.
+
+Pass `metadata_keys` when a policy-aware consumer needs selected top-level metadata keys:
+
+```python
+results = mem.recall(
+    "deployment policy",
+    top_k=10,
+    metadata_keys=["project_id", "policy_version"],
+)
+```
+
+Projection happens after ranking and scope filtering, never changes recall counters, skips synthetic rows, and issues at most one query per physical memory tier. It accepts at most 500 results and 32 keys, with a 16 KiB projected-metadata cap per result. Unrequested metadata is never returned, and enhanced-recall caches remain compact.
 
 **Examples:**
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -133,7 +133,8 @@ results = mem.recall(
     temporal_halflife: float = None,      # Hours for decay (default: 168)
     vec_weight: float = None,             # Override vector scoring weight
     fts_weight: float = None,             # Override FTS scoring weight
-    importance_weight: float = None       # Override importance weight
+    importance_weight: float = None,      # Override importance weight
+    metadata_keys: list[str] = None       # Optional top-level metadata allowlist
 )
 ```
 
@@ -149,7 +150,7 @@ results = mem.recall(
 )
 ```
 
-Projection happens after ranking and scope filtering, never changes recall counters, skips synthetic rows, and issues at most one query per physical memory tier. It accepts at most 500 results and 32 keys, with a 16 KiB projected-metadata cap per result. Unrequested metadata is never returned, and enhanced-recall caches remain compact.
+Projection happens after ranking and scope filtering and reads only the local SQLite `working_memory` and `episodic_memory` tiers. It never changes recall counters, skips synthetic/external rows, and issues at most one query per physical tier. It accepts at most 500 results and 32 keys, with a 16 KiB projected-metadata cap per result. Unrequested metadata is never returned, and projected metadata is not stored in enhanced-recall cache payloads.
 
 **Examples:**
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -28,6 +28,7 @@ from mnemosyne.core._connection_gc import collect_connection_cycles
 from mnemosyne.core.config import resolve_beam_runtime
 
 logger = logging.getLogger(__name__)
+_RECALL_METADATA_MAX_BYTES = 16 * 1024
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Optional, Any, Set, Union, Tuple, Callable
 from pathlib import Path
@@ -7434,6 +7435,81 @@ class BeamMemory:
             }
 
         return final_results
+
+    def _hydrate_recall_metadata(
+        self,
+        results: List[Dict],
+        metadata_keys: Union[List[str], Tuple[str, ...]],
+    ) -> List[Dict]:
+        """Return an allowlisted projection for an authenticated recall page.
+
+        Public callers enter through ``Mnemosyne.recall(metadata_keys=...)`` so
+        arbitrary ids cannot bypass the filters that produced the page. This
+        helper hydrates with at most one query per physical tier; synthetic
+        rows are copied unchanged.
+        """
+        if not isinstance(results, list):
+            raise ValueError("results must be a list")
+        if isinstance(metadata_keys, (str, bytes)) or not isinstance(metadata_keys, (list, tuple)):
+            raise ValueError("metadata_keys must be a list or tuple of strings")
+        if len(results) > 500:
+            raise ValueError("at most 500 recall results can be hydrated at once")
+        if len(metadata_keys) > 32:
+            raise ValueError("at most 32 metadata keys can be requested")
+
+        keys: List[str] = []
+        seen_keys = set()
+        for key in metadata_keys:
+            if not isinstance(key, str) or not key or len(key) > 128:
+                raise ValueError("metadata keys must be non-empty strings up to 128 characters")
+            if key not in seen_keys:
+                seen_keys.add(key)
+                keys.append(key)
+
+        if not all(isinstance(result, dict) for result in results):
+            raise ValueError("each recall result must be a dictionary")
+        hydrated = [dict(result) for result in results]
+        if not keys or not hydrated:
+            return hydrated
+
+        ids_by_tier = {
+            "working": [result.get("id") for result in hydrated if result.get("tier") == "working"],
+            "episodic": [result.get("id") for result in hydrated if result.get("tier") == "episodic"],
+        }
+        metadata_by_result = {}
+        for tier, table in (("working", "working_memory"), ("episodic", "episodic_memory")):
+            ids = list(dict.fromkeys(memory_id for memory_id in ids_by_tier[tier] if isinstance(memory_id, str)))
+            if not ids:
+                continue
+            placeholders = ",".join("?" * len(ids))
+            rows = self.conn.execute(
+                f"SELECT id, metadata_json FROM {table} WHERE id IN ({placeholders})",
+                ids,
+            ).fetchall()
+            for row in rows:
+                try:
+                    metadata = json.loads(row["metadata_json"] or "{}")
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                projected = {
+                    key: metadata[key] for key in keys if key in metadata
+                }
+                encoded = json.dumps(
+                    projected,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                if len(encoded) > _RECALL_METADATA_MAX_BYTES:
+                    raise ValueError("projected metadata exceeds 16384 bytes")
+                metadata_by_result[(tier, row["id"])] = projected
+
+        for result in hydrated:
+            result_key = (result.get("tier"), result.get("id"))
+            if result_key in metadata_by_result:
+                result["metadata"] = metadata_by_result[result_key]
+        return hydrated
 
     # Bump whenever the enhanced-recall ranking algorithm changes so entries
     # cached under an older digest are not reused. Part of the hashed payload;

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -18,7 +18,7 @@ import logging
 import threading
 import tempfile
 from datetime import datetime, timezone
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union
 from pathlib import Path
 
 import os
@@ -662,7 +662,8 @@ class Mnemosyne:
                vec_weight: float = None,
                fts_weight: float = None,
                importance_weight: float = None,
-               explain: bool = False) -> List[Dict]:
+               explain: bool = False,
+               metadata_keys: Optional[List[str]] = None) -> Union[List[Dict], Dict[str, Any]]:
         """
         Search memories with hybrid relevance scoring.
         Uses BEAM episodic + working memory retrieval (sqlite-vec + FTS5).
@@ -670,33 +671,50 @@ class Mnemosyne:
         Supports multi-agent identity filtering: author_id, author_type, channel_id.
         Supports temporal scoring: temporal_weight, query_time, temporal_halflife.
         Supports scoring weight overrides: vec_weight, fts_weight, importance_weight.
+        metadata_keys: Optional allowlist of stored top-level metadata keys to
+            project onto the results produced by this recall call.
         """
         import os as _os
+        payload: Any
         if _os.environ.get("MNEMOSYNE_ENHANCED_RECALL", "0") == "1":
-            return self.beam.recall_enhanced(query, top_k=top_k,
-                                             from_date=from_date, to_date=to_date,
-                                             source=source, topic=topic,
-                                             author_id=author_id, author_type=author_type,
-                                             channel_id=channel_id,
-                                             temporal_weight=temporal_weight,
-                                             query_time=query_time,
-                                             temporal_halflife=temporal_halflife,
-                                             vec_weight=vec_weight,
-                                             fts_weight=fts_weight,
-                                             importance_weight=importance_weight,
-                                             explain=explain)
-        return self.beam.recall(query, top_k=top_k,
-                                from_date=from_date, to_date=to_date,
-                                source=source, topic=topic,
-                                author_id=author_id, author_type=author_type,
-                                channel_id=channel_id,
-                                temporal_weight=temporal_weight,
-                                query_time=query_time,
-                                temporal_halflife=temporal_halflife,
-                                vec_weight=vec_weight,
-                                fts_weight=fts_weight,
-                                importance_weight=importance_weight,
-                                explain=explain)
+            payload = self.beam.recall_enhanced(
+                query, top_k=top_k,
+                from_date=from_date, to_date=to_date,
+                source=source, topic=topic,
+                author_id=author_id, author_type=author_type,
+                channel_id=channel_id,
+                temporal_weight=temporal_weight,
+                query_time=query_time,
+                temporal_halflife=temporal_halflife,
+                vec_weight=vec_weight,
+                fts_weight=fts_weight,
+                importance_weight=importance_weight,
+                explain=explain,
+            )
+        else:
+            payload = self.beam.recall(
+                query, top_k=top_k,
+                from_date=from_date, to_date=to_date,
+                source=source, topic=topic,
+                author_id=author_id, author_type=author_type,
+                channel_id=channel_id,
+                temporal_weight=temporal_weight,
+                query_time=query_time,
+                temporal_halflife=temporal_halflife,
+                vec_weight=vec_weight,
+                fts_weight=fts_weight,
+                importance_weight=importance_weight,
+                explain=explain,
+            )
+        if metadata_keys is None:
+            return payload
+        if explain:
+            projected = dict(payload)
+            projected["results"] = self.beam._hydrate_recall_metadata(
+                payload["results"], metadata_keys
+            )
+            return projected
+        return self.beam._hydrate_recall_metadata(payload, metadata_keys)
 
     def _emit_wrapper(self, event_type: str, memory_id: str, **kwargs) -> None:
         """Emit a streaming event through the Mnemosyne wrapper layer."""
@@ -1302,7 +1320,7 @@ _default_instance = None
 _default_bank = "default"
 
 
-def _get_default(bank: str = None):
+def _get_default(bank: Optional[str] = None):
     """Get or create the default Mnemosyne instance. Supports bank switching."""
     global _default_instance, _default_bank
     target_bank = bank or _default_bank or "default"
@@ -1353,7 +1371,8 @@ def recall(query: str, top_k: int = 5, *,
            fts_weight: float = None,
            importance_weight: float = None,
            explain: bool = False,
-           bank: str = None) -> List[Dict]:
+           metadata_keys: Optional[List[str]] = None,
+           bank: Optional[str] = None) -> Union[List[Dict], Dict[str, Any]]:
     """Search memories using the global instance with temporal filtering and scoring"""
     return _get_default(bank).recall(query, top_k,
                                      from_date=from_date, to_date=to_date,
@@ -1364,7 +1383,8 @@ def recall(query: str, top_k: int = 5, *,
                                      vec_weight=vec_weight,
                                      fts_weight=fts_weight,
                                      importance_weight=importance_weight,
-                                     explain=explain)
+                                     explain=explain,
+                                     metadata_keys=metadata_keys)
 
 
 def get_context(limit: int = 10, bank: str = None) -> List[Dict]:

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -156,7 +156,7 @@ def _export_completeness(conn: sqlite3.Connection, *, include_sync_events: bool)
         for field in sorted(set(actual_fields) - exported_fields):
             restore_default = _sqlite_restore_default(actual_fields[field])
             if restore_default is _UNKNOWN_RESTORE_DEFAULT:
-                predicate = f"{_quoted_identifier(field)} IS NOT NULL"
+                predicate = "1 = 1"
                 params = ()
             else:
                 predicate = f"{_quoted_identifier(field)} IS NOT ?"
@@ -931,23 +931,10 @@ class Mnemosyne:
         """Get consolidation history."""
         return self.beam.get_consolidation_log(limit=limit)
 
-    def export_to_file(
-        self, output_path: str, include_sync_events: bool = False
-    ) -> Dict:
-        """
-        Export supported Mnemosyne data to a portable JSON file. The additive
-        completeness manifest discloses omitted persisted surfaces and fields,
-        so a successful file write never implies a lossless database backup.
-
-        Schema version 1.3 adds the always-present ``canonical_facts`` section.
-        1.2 (post-sync) adds an optional ``sync_events`` section. Previous
-        versions (1.0, 1.1, 1.2) are still importable; ``sync_events`` presence
-        is keyed off the section itself on import, not the version number.
-        """
-        from mnemosyne.core.triples import TripleStore
-        from mnemosyne.core.annotations import AnnotationStore
-        from mnemosyne.core.canonical import CanonicalStore
-        import json as _json
+    def _build_portable_export(
+        self, include_sync_events: bool = False
+    ) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        """Build the portable payload and completeness manifest."""
 
         # Build export metadata with device_id when available
         meta: Dict[str, Any] = {
@@ -998,23 +985,17 @@ class Mnemosyne:
         """)
         export["legacy_embeddings"] = [dict(row) for row in cursor.fetchall()]
 
-        # Triples (current-truth temporal facts; post-E6 scope)
-        triples = TripleStore(db_path=self.db_path)
-        export["triples"] = triples.export_all()
-
-        # Annotations (post-E6: multi-valued mentions, facts, occurred_on,
-        # has_source). Pre-E6 backups won't have this key — the import path
-        # handles that gracefully.
-        annotations = AnnotationStore(db_path=self.db_path)
-        export["annotations"] = annotations.export_all()
-
-        # Canonical facts: owner-scoped single-source-of-truth identity, with
-        # history. These are AUTHORED (not derived), so omitting them made a
-        # JSON restore silently lossy. CanonicalStore already exposes
-        # export_all/import_all (same contract as triples/annotations); they
-        # were simply never wired into the file export.
-        canonical = CanonicalStore(db_path=self.db_path)
-        export["canonical_facts"] = canonical.export_all()
+        # Read every surface through the shared connection so one SQLite read
+        # transaction can hold the complete export at a single snapshot.
+        cursor.execute("""
+            SELECT id, subject, predicate, object, valid_from, valid_until,
+                   source, confidence, created_at
+            FROM triples
+            ORDER BY id
+        """)
+        export["triples"] = [dict(row) for row in cursor.fetchall()]
+        export["annotations"] = self.beam.annotations.export_all()
+        export["canonical_facts"] = self.beam.canonical.export_all()
 
         # Sync events (optional, schema 1.2)
         if include_sync_events:
@@ -1035,6 +1016,22 @@ class Mnemosyne:
             self.conn, include_sync_events=include_sync_events
         )
         meta["completeness"] = completeness
+        return export, completeness
+
+    def export_to_file(
+        self, output_path: str, include_sync_events: bool = False
+    ) -> Dict:
+        """Export supported data and its completeness from one DB snapshot."""
+        import json as _json
+
+        owns_transaction = not self.conn.in_transaction
+        if owns_transaction:
+            self.conn.execute("BEGIN")
+        try:
+            export, completeness = self._build_portable_export(include_sync_events)
+        finally:
+            if owns_transaction:
+                self.conn.rollback()
 
         with open(output_path, "w", encoding="utf-8") as f:
             _json.dump(export, f, indent=2, ensure_ascii=False, default=str)

--- a/tests/test_export_snapshot_integrity.py
+++ b/tests/test_export_snapshot_integrity.py
@@ -1,0 +1,96 @@
+"""Regression coverage for portable-export snapshot integrity."""
+
+import json
+import sqlite3
+import threading
+
+from mnemosyne.core.memory import Mnemosyne, _export_completeness
+
+
+def test_export_payload_and_manifest_share_one_read_snapshot(tmp_path, monkeypatch):
+    db_path = tmp_path / "snapshot.db"
+    memory = Mnemosyne(db_path=db_path)
+    writer_started = threading.Event()
+    writer_done = threading.Event()
+    writer_errors = []
+    original_export = memory.beam.export_to_dict
+
+    def export_then_pause():
+        payload = original_export()
+        writer_started.set()
+        assert writer_done.wait(5), "concurrent writer did not finish"
+        return payload
+
+    def write_omitted_surface():
+        assert writer_started.wait(5), "export did not reach its read snapshot"
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO working_memory
+                        (id, content, timestamp, session_id, pinned)
+                    VALUES ('late-memory', 'late write', '2026-01-01', 'default', 1)
+                    """
+                )
+        except Exception as exc:  # pragma: no cover - surfaced below
+            writer_errors.append(exc)
+        finally:
+            writer_done.set()
+
+    monkeypatch.setattr(memory.beam, "export_to_dict", export_then_pause)
+    writer = threading.Thread(target=write_omitted_surface)
+    writer.start()
+    output_path = tmp_path / "snapshot.json"
+    result = memory.export_to_file(str(output_path))
+    writer.join(5)
+
+    assert not writer.is_alive()
+    assert writer_errors == []
+    assert memory.conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 1
+    exported = json.loads(output_path.read_text(encoding="utf-8"))
+    partial = {
+        surface["section"]: surface
+        for surface in exported["mnemosyne_export"]["completeness"]["partial_surfaces"]
+    }
+    assert exported["working_memory"] == []
+    assert result["complete"] is True
+    assert "working_memory" not in partial
+
+
+def test_export_preserves_caller_owned_transaction(tmp_path):
+    memory = Mnemosyne(db_path=tmp_path / "caller.db")
+    memory.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    memory.conn.commit()
+    memory.conn.execute("INSERT INTO caller_marker VALUES ('uncommitted')")
+
+    memory.export_to_file(str(tmp_path / "caller.json"))
+
+    assert memory.conn.in_transaction is True
+    assert memory.conn.execute("SELECT value FROM caller_marker").fetchone()[0] == "uncommitted"
+    memory.conn.rollback()
+    assert memory.conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+
+
+def test_unknown_expression_default_counts_null_source_rows():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE working_memory (
+            id TEXT PRIMARY KEY,
+            generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO working_memory (id, generated_at) VALUES ('null-source', NULL)"
+    )
+
+    manifest = _export_completeness(conn, include_sync_events=False)
+    partial = {surface["section"]: surface for surface in manifest["partial_surfaces"]}
+    omitted = {
+        field["field"]: field["affected_rows"]
+        for field in partial["working_memory"]["omitted_fields"]
+    }
+
+    assert manifest["complete"] is False
+    assert omitted["generated_at"] == 1

--- a/tests/test_recall_metadata_projection.py
+++ b/tests/test_recall_metadata_projection.py
@@ -1,0 +1,212 @@
+import json
+from typing import Any, cast
+
+import pytest
+
+import mnemosyne
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.memory import Mnemosyne
+
+
+def _rows(payload: Any) -> list[dict[str, Any]]:
+    assert isinstance(payload, list)
+    return payload
+
+
+def _envelope(payload: Any) -> dict[str, Any]:
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _insert_episodic(beam, memory_id, content, metadata):
+    beam.conn.execute(
+        """
+        INSERT INTO episodic_memory
+            (id, content, source, timestamp, session_id, importance, metadata_json, scope)
+        VALUES (?, ?, 'test', '2026-01-01T00:00:00+00:00', ?, 0.8, ?, 'global')
+        """,
+        (memory_id, content, beam.session_id, json.dumps(metadata)),
+    )
+    beam.conn.commit()
+
+
+def test_projection_is_opt_in_allowlisted_and_non_mutating(tmp_path):
+    mem = Mnemosyne(db_path=tmp_path / "metadata.db", session_id="test")
+    memory_id = mem.remember(
+        "unique metadata projection probe",
+        metadata={"project_id": "p1", "private_note": "hidden", "count": 3},
+        scope="global",
+    )
+    compact = _rows(mem.recall("unique metadata projection probe", top_k=5))
+    assert "metadata" not in next(row for row in compact if row["id"] == memory_id)
+
+    hydrated = _rows(mem.recall(
+        "unique metadata projection probe",
+        top_k=5,
+        metadata_keys=["project_id", "count"],
+    ))
+    projected = next(row for row in hydrated if row["id"] == memory_id)
+    assert projected["metadata"] == {"project_id": "p1", "count": 3}
+    assert "private_note" not in projected["metadata"]
+    assert "metadata" not in next(row for row in compact if row["id"] == memory_id)
+
+
+def test_projection_bulk_hydrates_cross_tier_id_collision_in_two_queries(tmp_path):
+    beam = BeamMemory(session_id="test", db_path=tmp_path / "bulk.db")
+    shared_id = beam.remember(
+        "working projection marker",
+        metadata={"project_id": "working-project"},
+        scope="global",
+    )
+    _insert_episodic(
+        beam,
+        shared_id,
+        "episodic projection marker",
+        {"project_id": "episodic-project"},
+    )
+    results = [
+        {"id": shared_id, "tier": "working", "content": "working"},
+        {"id": shared_id, "tier": "episodic", "content": "episodic"},
+        {"id": "cf_synthetic", "tier": "fact", "content": "synthetic"},
+    ]
+    statements = []
+    beam.conn.set_trace_callback(statements.append)
+    try:
+        hydrated = beam._hydrate_recall_metadata(results, ["project_id"])
+    finally:
+        beam.conn.set_trace_callback(None)
+
+    queries = [s for s in statements if s.startswith("SELECT id, metadata_json FROM")]
+    assert len(queries) == 2
+    assert hydrated[0]["metadata"] == {"project_id": "working-project"}
+    assert hydrated[1]["metadata"] == {"project_id": "episodic-project"}
+    assert "metadata" not in hydrated[2]
+
+
+def test_module_level_recall_supports_projection(tmp_path, monkeypatch):
+    mem = Mnemosyne(db_path=tmp_path / "module.db", session_id="test")
+    memory_id = mem.remember(
+        "module projection marker",
+        metadata={"project_id": "module-project"},
+        scope="global",
+    )
+    monkeypatch.setattr("mnemosyne.core.memory._get_default", lambda _bank=None: mem)
+    results = _rows(mnemosyne.recall(
+        "module projection marker",
+        metadata_keys=["project_id"],
+    ))
+    result = next(row for row in results if row["id"] == memory_id)
+    assert result["metadata"] == {"project_id": "module-project"}
+
+
+@pytest.mark.parametrize(
+    "metadata_keys",
+    ["project_id", [""], [1], ["x" * 129], ["x"] * 33],
+)
+def test_projection_rejects_invalid_key_requests(tmp_path, metadata_keys):
+    mem = Mnemosyne(db_path=tmp_path / "invalid.db", session_id="test")
+    with pytest.raises(ValueError):
+        mem.recall("missing", metadata_keys=metadata_keys)
+
+
+def test_projection_handles_malformed_metadata_and_duplicate_keys(tmp_path):
+    mem = Mnemosyne(db_path=tmp_path / "malformed.db", session_id="test")
+    memory_id = mem.remember("malformed metadata marker", scope="global")
+    mem.beam.conn.execute(
+        "UPDATE working_memory SET metadata_json = ? WHERE id = ?",
+        ("not-json", memory_id),
+    )
+    mem.beam.conn.commit()
+    results = _rows(mem.recall(
+        "malformed metadata marker",
+        metadata_keys=["project_id", "project_id"],
+    ))
+    result = next(row for row in results if row["id"] == memory_id)
+    assert result["metadata"] == {}
+
+
+def test_projection_rejects_oversized_values_and_malformed_pages(tmp_path):
+    beam = BeamMemory(session_id="test", db_path=tmp_path / "limits.db")
+    memory_id = beam.remember(
+        "oversized metadata marker",
+        metadata={"large": "x" * (16 * 1024)},
+        scope="global",
+    )
+    with pytest.raises(ValueError, match="exceeds 16384 bytes"):
+        beam._hydrate_recall_metadata(
+            [{"id": memory_id, "tier": "working"}],
+            ["large"],
+        )
+    with pytest.raises(ValueError, match="dictionary"):
+        beam._hydrate_recall_metadata(cast(Any, ["not-a-result"]), ["large"])
+    with pytest.raises(ValueError, match="at most 500"):
+        beam._hydrate_recall_metadata([{}] * 501, ["large"])
+
+
+def test_empty_projection_returns_copies_without_queries(tmp_path):
+    beam = BeamMemory(session_id="test", db_path=tmp_path / "empty.db")
+    results = [{"id": "missing", "tier": "working"}]
+    statements = []
+    beam.conn.set_trace_callback(statements.append)
+    try:
+        hydrated = beam._hydrate_recall_metadata(results, ())
+    finally:
+        beam.conn.set_trace_callback(None)
+    assert hydrated == results
+    assert hydrated is not results
+    assert hydrated[0] is not results[0]
+    assert not any("metadata_json" in statement for statement in statements)
+
+
+def test_projection_cannot_bypass_recall_session_scope(tmp_path):
+    db_path = tmp_path / "scope.db"
+    writer = Mnemosyne(db_path=db_path, session_id="private-session")
+    private_id = writer.remember(
+        "session-private metadata probe",
+        metadata={"project_id": "private-project"},
+        scope="session",
+    )
+    reader = Mnemosyne(db_path=db_path, session_id="other-session")
+    results = _rows(reader.recall(
+        "session-private metadata probe",
+        top_k=10,
+        metadata_keys=["project_id"],
+    ))
+    assert private_id not in {row["id"] for row in results}
+
+
+def test_projection_preserves_explain_envelope(tmp_path):
+    mem = Mnemosyne(db_path=tmp_path / "explain.db", session_id="test")
+    memory_id = mem.remember(
+        "explain projection marker",
+        metadata={"project_id": "explain-project"},
+        scope="global",
+    )
+    payload = _envelope(mem.recall(
+        "explain projection marker",
+        top_k=5,
+        explain=True,
+        metadata_keys=["project_id"],
+    ))
+    result = next(row for row in payload["results"] if row["id"] == memory_id)
+    assert result["metadata"] == {"project_id": "explain-project"}
+    assert payload["explain"]
+
+
+def test_projection_does_not_expand_enhanced_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    mem = Mnemosyne(db_path=tmp_path / "cache.db", session_id="test")
+    memory_id = mem.remember(
+        "enhanced cache projection marker",
+        metadata={"project_id": "cache-project"},
+        scope="global",
+    )
+    hydrated = _rows(mem.recall(
+        "enhanced cache projection marker",
+        metadata_keys=["project_id"],
+    ))
+    result = next(row for row in hydrated if row["id"] == memory_id)
+    assert result["metadata"] == {"project_id": "cache-project"}
+
+    compact = _rows(mem.recall("enhanced cache projection marker"))
+    assert "metadata" not in next(row for row in compact if row["id"] == memory_id)


### PR DESCRIPTION
Addresses E02 in #828.

## What changed

Recall results stay compact by default. Callers can now pass `metadata_keys=[...]` to `Mnemosyne.recall()` (and the module-level wrapper) to project selected top-level metadata after the normal scoped recall has completed.

The projection is deliberately allowlisted and bounded:

- no change to default recall output or ranking;
- scope and identity filters run before metadata projection;
- at most one metadata query per physical tier;
- synthetic fact rows are left untouched;
- maximum 500 results, 32 keys, and 16 KiB projected metadata per result;
- malformed stored metadata degrades to an empty projection;
- enhanced-recall cache entries remain compact.

## Why

The provider/policy integration needs project and provenance metadata after recall. The current result contract omits stored `metadata_json`, forcing consumers into per-result lookups. This adds a safe, explicit seam without exposing arbitrary metadata by default.

## Verification

Clean isolated environment (`TZ=UTC`, embeddings disabled, leaked `MNEMOSYNE*` and `NVIDIA_EMBEDDING*` variables unset):

- focused projection tests: **14 passed**;
- adjacent recall/scoring/cache/package tests: **233 passed, 1 skipped**;
- combined focused + adjacent: **247 passed, 1 skipped**;
- trial: 40 projected results, one metadata query, zero scope leaks, zero unrequested-key leaks, 41 ms;
- Ruff and `git diff --check`: clean.

The full core suite was **3292 passed, 36 failed, 15 skipped**. The failures are in pre-existing repair, optional sync-crypto, MCP/package surfaces outside this diff; the changed projection tests and adjacent recall suite are green.

No live Mnemosyne instance was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds opt-in `metadata_keys` projection to `Mnemosyne.recall()` and the module-level `recall()`.
- Preserves compact results, ranking, filtering, and synthetic fact rows by default.
- Hydrates metadata only after scope and identity filtering.
- Supports working and episodic tiers with one metadata query per physical tier.
- Limits projection to 500 results, 32 keys, and 16 KiB per result.
- Keeps unrequested metadata in local SQLite storage.
- Preserves compact enhanced-recall cache entries.

## Architecture and Privacy

The change adds a bounded projection step across working memory, episodic memory, and BEAM result handling. It does not change retrieval strategies, ranking, consolidation, veracity, or synchronization.

The allowlist and scope checks reduce metadata exposure. Malformed metadata produces an empty projection. Projection reads only local SQLite working and episodic rows after recall filtering. No remote service or synchronization path is added.

This preserves the local-first design. Hermes, MCP, and CLI integrations can use the existing recall APIs and request only required fields. No direct integration changes are required.

## Maintainability and Verification

The projection logic is isolated in `_hydrate_recall_metadata`. Explicit validation and size limits bound query and memory costs. The tests cover tier hydration, scope enforcement, malformed metadata, cache behavior, explain responses, and module-level recall. Documentation and the changelog define the API contract.

The export snapshot changes improve transaction consistency and completeness accounting. They are separate from metadata projection and add regression coverage.

Verification passed 247 focused and adjacent tests, with one skipped, plus documentation, Ruff, and diff checks. The full core suite retains pre-existing failures outside this change. Benchmark methodology is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->