### PR TITLE
fix(shmr): keep non-dense imports usable without NumPy

### DIFF
--- a/mnemosyne/core/shmr.py
+++ b/mnemosyne/core/shmr.py
@@ -11,17 +11,37 @@ This is Mnemosyne's signature reasoning layer -- no Honcho dreams, no Hindsight
 reflections, no Mem0 static graphs. Memories actively resonate and self-correct.
 """
 
+from __future__ import annotations
+
 import os
 import time
 import logging
 import json
-from typing import List, Dict, Optional
+from typing import TYPE_CHECKING, List, Dict, Optional
 
-import numpy as np
+if TYPE_CHECKING:  # pragma: no cover - static analysis only
+    import numpy as np
+else:
+    try:
+        import numpy as np
+    except ModuleNotFoundError:  # pragma: no cover - exercised via subprocess test
+        np = None
 
 from mnemosyne.core import embeddings as _embeddings
 
 logger = logging.getLogger("mnemosyne.shmr")
+
+
+class ShmrDenseCapabilityUnavailable(RuntimeError):
+    """Raised when a dense SHMR operation runs without NumPy installed."""
+
+
+def _require_numpy():
+    if np is None:
+        raise ShmrDenseCapabilityUnavailable(
+            "shmr_dense_unavailable: numpy is not installed"
+        )
+    return np
 
 # --- Config ---
 SHMR_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_SHMR_BATCH_SIZE", "50"))
@@ -74,6 +94,7 @@ def _init_schema(conn):
 
 def _embed(text: str) -> np.ndarray:
     """Embed text using Mnemosyne's embedding pipeline (BAAI/bge-small)."""
+    np = _require_numpy()
     emb = _embeddings.embed([text])
     if emb is None or len(emb) == 0:
         return np.zeros(EMBEDDING_DIM, dtype=np.float32)
@@ -85,6 +106,7 @@ def _embed(text: str) -> np.ndarray:
 
 def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
     """Cosine similarity between two normalized vectors."""
+    np = _require_numpy()
     a_norm = a / (np.linalg.norm(a) + 1e-8)
     b_norm = b / (np.linalg.norm(b) + 1e-8)
     return float(np.dot(a_norm, b_norm))
@@ -229,6 +251,7 @@ def _compute_harmony_score(
     Uses cosine similarity between belief embeddings and cluster centroid,
     plus a consistency bonus for beliefs that don't contradict each other.
     """
+    np = _require_numpy()
     if not beliefs or not cluster:
         return 0.0
 
@@ -370,6 +393,9 @@ def harmonize(beam, batch_size: int = None, max_iterations: int = None,
               similarity_threshold: float = None) -> Dict:
     """Run one harmonic cycle over recent memories.
 
+    Raises:
+        ShmrDenseCapabilityUnavailable: if NumPy is not installed.
+
     NOT wired into anything. There is no caller in the shipped code: sleep()
     does not invoke it, there is no MCP tool, and there is no CLI subcommand.
     Call it directly if you want it:
@@ -401,6 +427,7 @@ def harmonize(beam, batch_size: int = None, max_iterations: int = None,
     if similarity_threshold is None:
         similarity_threshold = SHMR_SIMILARITY_THRESHOLD
 
+    np = _require_numpy()
     t0 = time.perf_counter()
     _init_schema(beam.conn)
     cursor = beam.conn.cursor()
@@ -550,7 +577,11 @@ def recall_beliefs(beam, query: str, top_k: int = 10) -> List[Dict]:
     """Search harmonic beliefs for a given query.
 
     Used by recall() when harmonic=True flag is set.
+
+    Raises:
+        ShmrDenseCapabilityUnavailable: if NumPy is not installed.
     """
+    _require_numpy()
     cursor = beam.conn.cursor()
     _init_schema(beam.conn)
 

--- a/tests/test_shmr_numpy_optional.py
+++ b/tests/test_shmr_numpy_optional.py
@@ -90,6 +90,7 @@ def test_non_dense_surface_usable_without_numpy():
 
 
 def test_dense_entry_points_fail_deterministically_without_numpy(tmp_path):
+    db = str(tmp_path / "harmonize.db")
     result = _run_without_numpy(
         f"""
         from mnemosyne.core.shmr import (
@@ -102,7 +103,7 @@ def test_dense_entry_points_fail_deterministically_without_numpy(tmp_path):
         )
         import sqlite3
 
-        db = r"{tmp_path / "harmonize.db"}"
+        db = {db!r}
         beam_conn = sqlite3.connect(db)
 
         class _Beam:
@@ -138,12 +139,13 @@ def test_dense_entry_points_fail_deterministically_without_numpy(tmp_path):
 
 def test_no_state_mutation_before_capability_error(tmp_path):
     """The dense guard must run before schema creation or row writes."""
+    db = str(tmp_path / "state.db")
     result = _run_without_numpy(
         f"""
         from mnemosyne.core.shmr import recall_beliefs, ShmrDenseCapabilityUnavailable
         import sqlite3
 
-        db = r"{tmp_path / "state.db"}"
+        db = {db!r}
         beam_conn = sqlite3.connect(db)
         beam_conn.row_factory = sqlite3.Row
 

--- a/tests/test_shmr_numpy_optional.py
+++ b/tests/test_shmr_numpy_optional.py
@@ -89,9 +89,9 @@ def test_non_dense_surface_usable_without_numpy():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_dense_entry_points_fail_deterministically_without_numpy():
+def test_dense_entry_points_fail_deterministically_without_numpy(tmp_path):
     result = _run_without_numpy(
-        """
+        f"""
         from mnemosyne.core.shmr import (
             _cosine_similarity,
             _embed,
@@ -100,12 +100,21 @@ def test_dense_entry_points_fail_deterministically_without_numpy():
             recall_beliefs,
             ShmrDenseCapabilityUnavailable,
         )
+        import sqlite3
+
+        db = r"{tmp_path / "harmonize.db"}"
+        beam_conn = sqlite3.connect(db)
+
+        class _Beam:
+            conn = beam_conn
+            session_id = "test"
 
         for call in (
             lambda: _embed("probe"),
             lambda: _cosine_similarity(None, None),
             lambda: _compute_harmony_score([], []),
-            lambda: recall_beliefs(None, "query"),
+            lambda: recall_beliefs(_Beam(), "query"),
+            lambda: harmonize(_Beam()),
         ):
             try:
                 call()
@@ -114,15 +123,14 @@ def test_dense_entry_points_fail_deterministically_without_numpy():
             else:
                 raise AssertionError("dense call unexpectedly succeeded")
 
-        class _FakeBeam:
-            session_id = "test"
-
-        try:
-            harmonize(_FakeBeam())
-        except ShmrDenseCapabilityUnavailable:
-            pass
-        else:
-            raise AssertionError("harmonize unexpectedly succeeded")
+        tables = [
+            row[0]
+            for row in beam_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        ]
+        assert "harmonic_beliefs" not in tables
+        assert "memory_resonance_log" not in tables
         """
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_shmr_numpy_optional.py
+++ b/tests/test_shmr_numpy_optional.py
@@ -157,6 +157,10 @@ def test_no_state_mutation_before_capability_error(tmp_path):
             recall_beliefs(_Beam(), "query")
         except ShmrDenseCapabilityUnavailable:
             pass
+        else:
+            raise AssertionError(
+                "recall_beliefs unexpectedly returned without raising"
+            )
 
         tables = [
             row[0]

--- a/tests/test_shmr_numpy_optional.py
+++ b/tests/test_shmr_numpy_optional.py
@@ -1,0 +1,185 @@
+"""Regression tests for issue #834: SHMR stays importable without NumPy.
+
+Contract (confirmed by dplush in #834):
+
+- Importing ``mnemosyne.core.shmr`` succeeds without NumPy.
+- Non-dense paths remain usable without NumPy.
+- Dense-only entry points raise one deterministic capability error before
+  mutating state or doing work.
+- Existing dense behavior with NumPy installed is unchanged.
+
+The no-NumPy cases run in a subprocess so the module import boundary is
+exercised for real, not just simulated.
+"""
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_without_numpy(code: str) -> subprocess.CompletedProcess[str]:
+    """Run code in a fresh interpreter that cannot import NumPy."""
+    blocker = textwrap.dedent("""
+        import importlib.abc
+        import sys
+
+        class _BlockNumPy(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "numpy" or fullname.startswith("numpy."):
+                    raise ModuleNotFoundError(
+                        f"No module named {fullname!r} (blocked by test)"
+                    )
+                return None
+
+        sys.meta_path.insert(0, _BlockNumPy())
+        assert "numpy" not in sys.modules
+    """)
+    script = blocker + "\n" + textwrap.dedent(code)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def test_module_import_succeeds_without_numpy():
+    result = _run_without_numpy("import mnemosyne.core.shmr")
+    assert result.returncode == 0, result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_non_dense_surface_usable_without_numpy():
+    result = _run_without_numpy(
+        """
+        import sqlite3
+        from mnemosyne.core.shmr import (
+            FACTS_SCHEMA_SQL,
+            ShmrDenseCapabilityUnavailable,
+            _init_schema,
+            get_resonance_log,
+        )
+
+        class _BeamWithConn:
+            def __init__(self, conn):
+                self.conn = conn
+
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(FACTS_SCHEMA_SQL)
+        _init_schema(conn)
+
+        log = get_resonance_log(_BeamWithConn(conn))
+        assert isinstance(log, list)
+
+        try:
+            from mnemosyne.core.shmr import _embed
+        except ImportError:
+            pass
+        else:
+            try:
+                _embed("probe")
+            except ShmrDenseCapabilityUnavailable as exc:
+                assert "shmr_dense_unavailable" in str(exc)
+            else:
+                raise AssertionError("dense embed should fail without numpy")
+        """
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_dense_entry_points_fail_deterministically_without_numpy():
+    result = _run_without_numpy(
+        """
+        from mnemosyne.core.shmr import (
+            _cosine_similarity,
+            _embed,
+            _compute_harmony_score,
+            harmonize,
+            recall_beliefs,
+            ShmrDenseCapabilityUnavailable,
+        )
+
+        for call in (
+            lambda: _embed("probe"),
+            lambda: _cosine_similarity(None, None),
+            lambda: _compute_harmony_score([], []),
+            lambda: recall_beliefs(None, "query"),
+        ):
+            try:
+                call()
+            except ShmrDenseCapabilityUnavailable as exc:
+                assert str(exc) == "shmr_dense_unavailable: numpy is not installed"
+            else:
+                raise AssertionError("dense call unexpectedly succeeded")
+
+        class _FakeBeam:
+            session_id = "test"
+
+        try:
+            harmonize(_FakeBeam())
+        except ShmrDenseCapabilityUnavailable:
+            pass
+        else:
+            raise AssertionError("harmonize unexpectedly succeeded")
+        """
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_no_state_mutation_before_capability_error(tmp_path):
+    """The dense guard must run before schema creation or row writes."""
+    result = _run_without_numpy(
+        f"""
+        from mnemosyne.core.shmr import recall_beliefs, ShmrDenseCapabilityUnavailable
+        import sqlite3
+
+        db = r"{tmp_path / "state.db"}"
+        beam_conn = sqlite3.connect(db)
+        beam_conn.row_factory = sqlite3.Row
+
+        class _Beam:
+            conn = beam_conn
+            session_id = "test"
+
+        try:
+            recall_beliefs(_Beam(), "query")
+        except ShmrDenseCapabilityUnavailable:
+            pass
+
+        tables = [
+            row[0]
+            for row in beam_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        ]
+        print("TABLES:", sorted(tables))
+        assert "harmonic_beliefs" not in tables
+        assert "memory_resonance_log" not in tables
+        """
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_dense_behavior_unchanged_with_numpy(monkeypatch):
+    np = pytest.importorskip("numpy")
+    from mnemosyne.core import shmr
+
+    assert shmr.np is not None
+    monkeypatch.setattr(
+        shmr._embeddings, "embed",
+        lambda texts: np.full((len(texts), shmr.EMBEDDING_DIM), 0.5,
+                              dtype=np.float32),
+    )
+
+    emb = shmr._embed("probe")
+    assert emb.shape == (shmr.EMBEDDING_DIM,)
+    sim = shmr._cosine_similarity(emb, emb)
+    assert sim == pytest.approx(1.0, abs=1e-4)
+
+
+def test_capability_error_type_and_message():
+    from mnemosyne.core.shmr import ShmrDenseCapabilityUnavailable
+
+    assert issubclass(ShmrDenseCapabilityUnavailable, RuntimeError)


### PR DESCRIPTION
Fixes #834.

## What changed

`mnemosyne.core.shmr` imported NumPy unconditionally, so a minimal installation without NumPy could not even import the module — even though PR #31 established the base-install contract and the issue body confirmed that dense SHMR remains optional.

This change:

- replaces the unconditional `import numpy as np` with a guarded import (`np = None` on failure);
- adds `from __future__ import annotations` so `np.ndarray` type hints stay unevaluated;
- introduces `ShmrDenseCapabilityUnavailable(RuntimeError)` with a stable message (`shmr_dense_unavailable: numpy is not installed`);
- guards all dense-only entry points (`_embed`, `_cosine_similarity`, `_compute_harmony_score`, `harmonize`, `recall_beliefs`) so they fail deterministically before any work or state mutation;
- leaves non-dense surfaces (`FACTS_SCHEMA_SQL`, `_init_schema`, `_call_llm`, `_extract_json_from_llm_output`, `get_resonance_log`) fully usable without NumPy.

No scoring-semantic changes. No dense fallback without NumPy.

## Verification

Clean isolated environment (`TZ=UTC`, embeddings disabled):

- focused no-NumPy/dense regression tests: **11 passed**
- existing SHMR tests (with NumPy): **all passed**, confirming unchanged behavior
- full core suite: **3287 passed, 36 failed, 15 skipped = 98.9% pass rate**
  - 36 failures are pre-existing baseline issues in repair fd-binding, optional sync-crypto deps, and packaging/MCP surfaces — none touch SHMR or this diff
- Ruff clean; `git diff --check` clean

Addresses B16 in #827.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes NumPy optional for `mnemosyne.core.shmr`.

- Non-dense SHMR surfaces remain importable and usable without NumPy.
- Dense entry points fail before work or state mutation with `ShmrDenseCapabilityUnavailable`.
- Existing dense behavior and scoring semantics remain unchanged when NumPy is installed.
- No dense fallback implementation was added.

## Architectural impact

The change preserves the working, episodic, and BEAM memory tiers. It does not change retrieval, consolidation, veracity, synchronization, or benchmark methodology.

Hermes, MCP, and CLI surfaces receive no direct behavior changes. Local non-dense workflows can import SHMR without NumPy. Dense workflows receive the stable error `shmr_dense_unavailable: numpy is not installed`.

The guarded import removes an unnecessary runtime dependency. It adds no network access, remote service, or data-sharing path. It preserves Mnemosyne’s local-first design and privacy posture.

## Maintainability

`ShmrDenseCapabilityUnavailable` defines a clear contract for a missing dense capability. `_require_numpy()` centralizes the capability check. Postponed annotations preserve static typing without requiring NumPy at runtime.

The regression tests cover importability, non-dense operation, deterministic dense failures, no-mutation behavior, NumPy-enabled behavior, exact error text, and safe subprocess path handling.

This is the right call because it removes an unnecessary dependency without changing dense semantics or adding an unsupported fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->