### PR TITLE
fix(recall): configurable content cap with unchanged 500-character default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **Configurable recall content cap (#913).** `MNEMOSYNE_RECALL_CONTENT_CAP` lets operators override the per-result character limit while the default remains 500. The limit also covers enhanced associative results and cache hits. The enhanced-recall cache key now includes the cap, so cached results cannot cross between different configured limits.
 - **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 - **Hermes runtime-Python discovery (#938).** `mnemosyne-hermes runtime-python --json` reports the validated Python interpreter selected for Hermes, or fails closed when it cannot identify one. `--hermes-home` scopes discovery to that deployment; `--python` explicitly selects an interpreter.
 
+- **Configurable recall content cap (#913).** `MNEMOSYNE_RECALL_CONTENT_CAP` lets operators override the per-result character limit while the default remains 500. The limit also covers enhanced associative results and cache hits. The enhanced-recall cache key now includes the cap, so cached results cannot cross between different configured limits.
 - **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -380,6 +380,58 @@ WM_PINNED_IDS = set(
     if pid.strip()
 )
 EPISODIC_RECALL_LIMIT = int(os.environ.get("MNEMOSYNE_EP_LIMIT", "50000"))
+
+def _env_int(name: str, default: int) -> int:
+    """Parse a positive integer knob, falling back on empty/invalid values."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+        if value > 0:
+            return value
+    except ValueError:
+        pass
+    logger.warning("%s is not a positive integer; using default %s", name, default)
+    return default
+
+
+# Recall content cap: bounded by default at 500 chars per result to keep
+# the public recall contract stable (see #685). MNEMOSYNE_RECALL_CONTENT_CAP
+# opts into a higher limit; resolved once at IMPORT time (restart to
+# change). Empty/unset falls back silently, invalid or non-positive
+# values warn and fall back to 500. The cap is enforced at the shared
+# public-result boundary of recall() (see _cap_recall_results), covering
+# the linear producers, the polyphonic engine path, the MEMORIA
+# supplements and the fact-voice merge alike.
+RECALL_CONTENT_CAP = _env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500)
+
+
+def _cap_recall_content(content: Any) -> Any:
+    """Apply the public recall content cap to one result's content field."""
+    if isinstance(content, str) and len(content) > RECALL_CONTENT_CAP:
+        return content[:RECALL_CONTENT_CAP]
+    return content
+
+
+def _cap_recall_results(results: Any) -> Any:
+    """Shared public-result boundary for the recall content cap.
+
+    Enforces RECALL_CONTENT_CAP on every result leaving recall() or
+    recall_enhanced(), including associative additions and cache hits, whatever
+    producer built it: the six linear slices, the polyphonic engine mapper,
+    the MEMORIA structured-fact supplements (linear + polyphonic) and the
+    fact-voice merge. Feature-gated paths are exactly the ones that tend to
+    re-grow raw-content leaks, so capping at the boundary (not per producer)
+    keeps the #685 bounded-payload contract true by construction.
+    """
+    if not isinstance(results, list):
+        return results
+    for r in results:
+        if isinstance(r, dict) and "content" in r:
+            r["content"] = _cap_recall_content(r["content"])
+    return results
+
 SLEEP_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_SLEEP_BATCH", "5000"))
 SCRATCHPAD_MAX_ITEMS = int(os.environ.get("MNEMOSYNE_SP_MAX", "1000"))
 RECENCY_HALFLIFE_HOURS = float(os.environ.get("MNEMOSYNE_RECENCY_HALFLIFE", "168"))  # 1 week default
@@ -445,21 +497,6 @@ def _env_float(name: str, default: float) -> float:
             name, raw[:80], default,
         )
         return default
-
-
-def _env_int(name: str, default: int) -> int:
-    """Parse a positive integer knob, falling back on empty/invalid values."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-        if value > 0:
-            return value
-    except ValueError:
-        pass
-    logger.warning("%s is not a positive integer; using default %s", name, default)
-    return default
 
 
 # Conflict validation limits apply to one complete sleep(), not each source.
@@ -7172,13 +7209,13 @@ class BeamMemory:
                     "query": query,
                     "top_k": top_k,
                     "engine": "polyphonic",
-                    "results": poly_results,
+                    "results": _cap_recall_results(poly_results),
                     "explain": {
                         "unsupported": True,
                         "reason": "polyphonic recall explain is not implemented in v1; inspect per-result voice_scores instead.",
                     },
                 }
-            return poly_results
+            return _cap_recall_results(poly_results)
 
         results = []
         query_lower = query.lower()
@@ -7509,7 +7546,7 @@ class BeamMemory:
                 _track_literal_content("working", row["id"], row["content"])
                 results.append({
                     "id": row["id"],
-                    "content": row["content"][:500],
+                    "content": row["content"][:RECALL_CONTENT_CAP],
                     "source": row["source"],
                     "timestamp": row["timestamp"],
                     "tier": "working",
@@ -7627,7 +7664,7 @@ class BeamMemory:
                     _track_literal_content("working", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "working",
@@ -7689,7 +7726,7 @@ class BeamMemory:
                     _track_literal_content("episodic", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -7916,7 +7953,7 @@ class BeamMemory:
             _track_literal_content("episodic", row["id"], row["content"])
             results.append({
                 "id": row["id"],
-                "content": row["content"][:500],
+                "content": row["content"][:RECALL_CONTENT_CAP],
                 "source": row["source"],
                 "timestamp": row["timestamp"],
                 "tier": "episodic",
@@ -8024,7 +8061,7 @@ class BeamMemory:
                     _track_literal_content("episodic", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -8194,7 +8231,7 @@ class BeamMemory:
                             )
                             results.append({
                                 "id": memoria_source_id,
-                                "content": _row["content"][:500],
+                                "content": _row["content"][:RECALL_CONTENT_CAP],
                                 "source": _row["source"],
                                 "timestamp": _row["timestamp"],
                                 "tier": "memoria_source",
@@ -8356,17 +8393,17 @@ class BeamMemory:
                 "query": query,
                 "top_k": top_k,
                 "engine": "linear",
-                "results": final_results,
+                "results": _cap_recall_results(final_results),
                 "explain": _explain_trace.to_dict(),
             }
 
-        return final_results
+        return _cap_recall_results(final_results)
 
     # Bump whenever the enhanced-recall candidate or ranking algorithm changes
     # so entries cached under an older digest are not reused. Part of the
     # hashed payload; the opaque key keeps the "v2:" prefix because QueryCache's
     # opaque-path recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
-    _ENHANCED_RECALL_CACHE_VERSION = 7
+    _ENHANCED_RECALL_CACHE_VERSION = 8
 
     def _enhanced_recall_cache_key(
         self,
@@ -8475,6 +8512,7 @@ class BeamMemory:
                 "synonym_module": expand_query is not None,
                 "associative_graph": self.episodic_graph is not None,
                 "embeddings_available": _embeddings.available(),
+                "recall_content_cap": RECALL_CONTENT_CAP,
                 "embedding_model": getattr(_embeddings, "_DEFAULT_MODEL", None),
                 "embedding_dimension": getattr(_embeddings, "EMBEDDING_DIM", None),
                 "embedding_query_prefix": os.environ.get("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", ""),
@@ -8619,7 +8657,7 @@ class BeamMemory:
             # ``top_k`` is part of the v2 digest, so truncating here would
             # make a hit differ from the cached pipeline result (notably when
             # associative retrieval appends related memories after top-k).
-            return cached
+            return _cap_recall_results(cached)
 
         # 4. Run base recall with expanded query
         results = self.recall(
@@ -8714,7 +8752,10 @@ class BeamMemory:
             except Exception:
                 logger.info("Regex extraction failed, skipping", exc_info=True)
 
-        # 9. Cache results
+        # 9. Cap after all augmentation, before persistence and public return.
+        results = _cap_recall_results(results)
+
+        # 10. Cache results
         if use_cache and not explain and hasattr(self, '_query_cache') and self._query_cache is not None:
             self._query_cache.put_opaque(cache_key, results)
 
@@ -9262,10 +9303,12 @@ class BeamMemory:
     def _polyphonic_row_to_dict(self, row, *, tier_label: str) -> Dict:
         """Shared row → recall-dict mapper. /review caught the
         near-duplicate column mapping across episodic/working
-        branches -- single helper now."""
+        branches -- single helper now. Content is capped through
+        _cap_recall_content so the polyphonic result shape obeys the
+        same public recall content bound as the linear producers."""
         d = {
             "id": row["id"],
-            "content": row["content"],
+            "content": _cap_recall_content(row["content"]),
             "source": row["source"],
             "timestamp": row["timestamp"],
             "session_id": row["session_id"] if "session_id" in row.keys() else None,
@@ -9400,9 +9443,10 @@ class BeamMemory:
         except Exception:
             pass  # consolidated_facts search is best-effort
 
-        # Sort by score descending and respect top_k
+        # Sort by score descending, respect top_k, and apply the same public
+        # content boundary as recall() / recall_enhanced().
         results.sort(key=lambda x: x["score"], reverse=True)
-        return results[:top_k]
+        return _cap_recall_results(results[:top_k])
 
     def get_episodic_stats(self, author_id: str = None, author_type: str = None,
                            channel_id: str = None) -> Dict:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -380,6 +380,58 @@ WM_PINNED_IDS = set(
     if pid.strip()
 )
 EPISODIC_RECALL_LIMIT = int(os.environ.get("MNEMOSYNE_EP_LIMIT", "50000"))
+
+def _env_int(name: str, default: int) -> int:
+    """Parse a positive integer knob, falling back on empty/invalid values."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+        if value > 0:
+            return value
+    except ValueError:
+        pass
+    logger.warning("%s is not a positive integer; using default %s", name, default)
+    return default
+
+
+# Recall content cap: bounded by default at 500 chars per result to keep
+# the public recall contract stable (see #685). MNEMOSYNE_RECALL_CONTENT_CAP
+# opts into a higher limit; resolved once at IMPORT time (restart to
+# change). Empty/unset falls back silently, invalid or non-positive
+# values warn and fall back to 500. The cap is enforced at the shared
+# public-result boundary of recall() (see _cap_recall_results), covering
+# the linear producers, the polyphonic engine path, the MEMORIA
+# supplements and the fact-voice merge alike.
+RECALL_CONTENT_CAP = _env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500)
+
+
+def _cap_recall_content(content: Any) -> Any:
+    """Apply the public recall content cap to one result's content field."""
+    if isinstance(content, str) and len(content) > RECALL_CONTENT_CAP:
+        return content[:RECALL_CONTENT_CAP]
+    return content
+
+
+def _cap_recall_results(results: Any) -> Any:
+    """Shared public-result boundary for the recall content cap.
+
+    Enforces RECALL_CONTENT_CAP on every result leaving recall() or
+    recall_enhanced(), including associative additions and cache hits, whatever
+    producer built it: the six linear slices, the polyphonic engine mapper,
+    the MEMORIA structured-fact supplements (linear + polyphonic) and the
+    fact-voice merge. Feature-gated paths are exactly the ones that tend to
+    re-grow raw-content leaks, so capping at the boundary (not per producer)
+    keeps the #685 bounded-payload contract true by construction.
+    """
+    if not isinstance(results, list):
+        return results
+    for r in results:
+        if isinstance(r, dict) and "content" in r:
+            r["content"] = _cap_recall_content(r["content"])
+    return results
+
 SLEEP_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_SLEEP_BATCH", "5000"))
 SCRATCHPAD_MAX_ITEMS = int(os.environ.get("MNEMOSYNE_SP_MAX", "1000"))
 RECENCY_HALFLIFE_HOURS = float(os.environ.get("MNEMOSYNE_RECENCY_HALFLIFE", "168"))  # 1 week default
@@ -445,21 +497,6 @@ def _env_float(name: str, default: float) -> float:
             name, raw[:80], default,
         )
         return default
-
-
-def _env_int(name: str, default: int) -> int:
-    """Parse a positive integer knob, falling back on empty/invalid values."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-        if value > 0:
-            return value
-    except ValueError:
-        pass
-    logger.warning("%s is not a positive integer; using default %s", name, default)
-    return default
 
 
 # Conflict validation limits apply to one complete sleep(), not each source.
@@ -7984,13 +8021,13 @@ class BeamMemory:
                     "query": query,
                     "top_k": top_k,
                     "engine": "polyphonic",
-                    "results": poly_results,
+                    "results": _cap_recall_results(poly_results),
                     "explain": {
                         "unsupported": True,
                         "reason": "polyphonic recall explain is not implemented in v1; inspect per-result voice_scores instead.",
                     },
                 }
-            return poly_results
+            return _cap_recall_results(poly_results)
 
         results = []
         query_lower = query.lower()
@@ -8321,7 +8358,7 @@ class BeamMemory:
                 _track_literal_content("working", row["id"], row["content"])
                 results.append({
                     "id": row["id"],
-                    "content": row["content"][:500],
+                    "content": row["content"][:RECALL_CONTENT_CAP],
                     "source": row["source"],
                     "timestamp": row["timestamp"],
                     "tier": "working",
@@ -8439,7 +8476,7 @@ class BeamMemory:
                     _track_literal_content("working", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "working",
@@ -8501,7 +8538,7 @@ class BeamMemory:
                     _track_literal_content("episodic", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -8839,7 +8876,7 @@ class BeamMemory:
             _track_literal_content("episodic", row["id"], row["content"])
             results.append({
                 "id": row["id"],
-                "content": row["content"][:500],
+                "content": row["content"][:RECALL_CONTENT_CAP],
                 "source": row["source"],
                 "timestamp": row["timestamp"],
                 "tier": "episodic",
@@ -8947,7 +8984,7 @@ class BeamMemory:
                     _track_literal_content("episodic", row["id"], row["content"])
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": row["content"][:RECALL_CONTENT_CAP],
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -9117,7 +9154,7 @@ class BeamMemory:
                             )
                             results.append({
                                 "id": memoria_source_id,
-                                "content": _row["content"][:500],
+                                "content": _row["content"][:RECALL_CONTENT_CAP],
                                 "source": _row["source"],
                                 "timestamp": _row["timestamp"],
                                 "tier": "memoria_source",
@@ -9279,17 +9316,17 @@ class BeamMemory:
                 "query": query,
                 "top_k": top_k,
                 "engine": "linear",
-                "results": final_results,
+                "results": _cap_recall_results(final_results),
                 "explain": _explain_trace.to_dict(),
             }
 
-        return final_results
+        return _cap_recall_results(final_results)
 
     # Bump whenever the enhanced-recall candidate or ranking algorithm changes
     # so entries cached under an older digest are not reused. Part of the
     # hashed payload; the opaque key keeps the "v2:" prefix because QueryCache's
     # opaque-path recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
-    _ENHANCED_RECALL_CACHE_VERSION = 8
+    _ENHANCED_RECALL_CACHE_VERSION = 9
     # NOTE: the key carries the env MNEMOSYNE_VEC_TYPE, not the table's
     # live DDL type — a reindex under a different type without a version
     # bump serves stale admission/ranking. Reindex flows must bump.
@@ -9429,6 +9466,7 @@ class BeamMemory:
                 "associative_graph": self.episodic_graph is not None,
                 "embeddings_available": _embeddings.available(),
                 "em_vec_admit": EM_VEC_ADMIT,
+                "recall_content_cap": RECALL_CONTENT_CAP,
                 "embedding_model": getattr(_embeddings, "_DEFAULT_MODEL", None),
                 "embedding_dimension": getattr(_embeddings, "EMBEDDING_DIM", None),
                 "embedding_query_prefix": os.environ.get("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", ""),
@@ -9574,7 +9612,7 @@ class BeamMemory:
             # ``top_k`` is part of the v2 digest, so truncating here would
             # make a hit differ from the cached pipeline result (notably when
             # associative retrieval appends related memories after top-k).
-            return cached
+            return _cap_recall_results(cached)
 
         # 4. Run base recall with expanded query
         results = self.recall(
@@ -9669,7 +9707,10 @@ class BeamMemory:
             except Exception:
                 logger.info("Regex extraction failed, skipping", exc_info=True)
 
-        # 9. Cache results (skip entirely when the key could not be built)
+        # 9. Cap after all augmentation, before persistence and public return.
+        results = _cap_recall_results(results)
+
+        # 10. Cache results (skip entirely when the key could not be built)
         if (cache_key is not None and use_cache and not explain
                 and hasattr(self, '_query_cache') and self._query_cache is not None):
             self._query_cache.put_opaque(cache_key, results)
@@ -10241,10 +10282,12 @@ class BeamMemory:
     def _polyphonic_row_to_dict(self, row, *, tier_label: str) -> Dict:
         """Shared row → recall-dict mapper. /review caught the
         near-duplicate column mapping across episodic/working
-        branches -- single helper now."""
+        branches -- single helper now. Content is capped through
+        _cap_recall_content so the polyphonic result shape obeys the
+        same public recall content bound as the linear producers."""
         d = {
             "id": row["id"],
-            "content": row["content"],
+            "content": _cap_recall_content(row["content"]),
             "source": row["source"],
             "timestamp": row["timestamp"],
             "session_id": row["session_id"] if "session_id" in row.keys() else None,
@@ -10379,9 +10422,10 @@ class BeamMemory:
         except Exception:
             pass  # consolidated_facts search is best-effort
 
-        # Sort by score descending and respect top_k
+        # Sort by score descending, respect top_k, and apply the same public
+        # content boundary as recall() / recall_enhanced().
         results.sort(key=lambda x: x["score"], reverse=True)
-        return results[:top_k]
+        return _cap_recall_results(results[:top_k])
 
     def get_episodic_stats(self, author_id: str = None, author_type: str = None,
                            channel_id: str = None) -> Dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,16 @@ between tests, and that default-disable the local LLM so tests don't
 make real CPU inference calls when a model is available on disk.
 """
 
+import os
+
+# Scrub deployment env BEFORE any test module imports mnemosyne.core.beam:
+# the module-level RECALL_CONTENT_CAP constant resolves at
+# first import, so a deployment-exported value baked in during collection
+# (alphabetical order controls which file imports first) would otherwise make
+# default-behavior tests environment-dependent. Tests that want custom values
+# set them explicitly on the resolved module attributes.
+os.environ.pop("MNEMOSYNE_RECALL_CONTENT_CAP", None)
+
 import pytest
 
 

--- a/tests/test_beam_content_cap.py
+++ b/tests/test_beam_content_cap.py
@@ -1,0 +1,529 @@
+"""Regression tests: bounded recall content cap (PR).
+
+Covers the maintainer review demands:
+- default stays 500 (public contract unchanged); env opts into a higher cap
+- invalid/non-positive/empty env values fall back with a warning
+- the cap is part of the enhanced-recall cache identity, so entries created
+  under one cap are never served under another
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Observe the library default regardless of the deployment env OR of
+    when beam was first imported: the module constant resolves at import,
+    so reset both the env and the resolved constant. conftest.py also scrubs
+    the env at module top (before any test module imports beam)."""
+    monkeypatch.delenv("MNEMOSYNE_RECALL_CONTENT_CAP", raising=False)
+    monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 500)
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    return tmp_path / "content_cap.db"
+
+
+class TestCapDefaults:
+    def test_default_is_500(self):
+        # Pins the SHIPPED default via a fresh subprocess import: the
+        # autouse fixture assigns the module attribute before this test
+        # runs, so comparing against in-process state would be vacuous
+        # (it passes even if the shipped initializer changed). A clean
+        # interpreter reads production beam.py with no env and no
+        # fixture interference — fails under any default mutation.
+        prog = (
+            "import sys\n"
+            f"sys.path.insert(0, {str(_REPO_ROOT)!r})\n"
+            "from mnemosyne.core import beam\n"
+            "print(beam.RECALL_CONTENT_CAP)\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", prog],
+            capture_output=True, text=True, timeout=120,
+            env={**os.environ, "MNEMOSYNE_NO_EMBEDDINGS": "1"},
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "500"
+
+    def test_shipped_default_mutation_is_caught(self, tmp_path):
+        # Meta-test: prove the subprocess probe above is not vacuous.
+        # Mutate the shipped initializer in a scratch copy the way a
+        # regression would (default 999) and require the same probe to
+        # FAIL there.
+        import shutil
+
+        scratch = tmp_path / "repo"
+        shutil.copytree(
+            _REPO_ROOT / "mnemosyne", scratch / "mnemosyne",
+            ignore=shutil.ignore_patterns(
+                "__pycache__", "*.pyc",
+            ),
+        )
+        assert set(scratch.iterdir()) == {scratch / "mnemosyne"}
+        init = scratch / "mnemosyne" / "core" / "beam.py"
+        source = init.read_text()
+        mutated = source.replace(
+            'RECALL_CONTENT_CAP = _env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500)',
+            'RECALL_CONTENT_CAP = _env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 999)',
+        )
+        assert mutated != source, "shipped initializer pattern not found"
+        init.write_text(mutated)
+        prog = (
+            "import sys\n"
+            f"sys.path.insert(0, {str(scratch)!r})\n"
+            "from mnemosyne.core import beam\n"
+            "from pathlib import Path\n"
+            f"assert str(Path(beam.__file__).resolve()) == {str(init)!r}\n"
+            "print(beam.RECALL_CONTENT_CAP)\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", prog],
+            capture_output=True, text=True, timeout=120,
+            env={**os.environ, "MNEMOSYNE_NO_EMBEDDINGS": "1"},
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "999", (
+            "probe must observe the shipped initializer, not fixture state"
+        )
+
+    def test_env_opt_in_raises(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CAP", "4000")
+        assert beam_module._env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500) == 4000
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CAP", "garbage")
+        assert beam_module._env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500) == 500
+
+    def test_empty_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CAP", "")
+        assert beam_module._env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500) == 500
+
+    def test_zero_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CAP", "0")
+        assert beam_module._env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500) == 500
+
+    def test_fresh_import_zero_env_uses_default(self):
+        assert self._fresh_import_cap("0") == "500"
+
+    def test_negative_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CAP", "-400")
+        assert beam_module._env_int("MNEMOSYNE_RECALL_CONTENT_CAP", 500) == 500
+
+    @staticmethod
+    def _fresh_import_cap(env_value: str) -> str:
+        """Import production beam.py in a clean interpreter with the env var
+        set, and read the resolved module constant — catches regressions
+        that hardcode the default or read a different env key (in-process
+        _env_int tests cannot distinguish those)."""
+        prog = (
+            "import sys\n"
+            f"sys.path.insert(0, {str(_REPO_ROOT)!r})\n"
+            "from mnemosyne.core import beam\n"
+            "print(beam.RECALL_CONTENT_CAP)\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", prog],
+            capture_output=True, text=True, timeout=120,
+            env={
+                **os.environ,
+                "MNEMOSYNE_NO_EMBEDDINGS": "1",
+                "MNEMOSYNE_RECALL_CONTENT_CAP": env_value,
+            },
+        )
+        assert out.returncode == 0, out.stderr
+        return out.stdout.strip()
+
+    def test_fresh_import_respects_opt_in(self):
+        assert self._fresh_import_cap("4000") == "4000"
+
+    def test_fresh_import_invalid_env_uses_default(self):
+        assert self._fresh_import_cap("garbage") == "500"
+
+    def test_fresh_import_empty_env_uses_default(self):
+        assert self._fresh_import_cap("") == "500"
+
+    def test_fresh_import_negative_env_uses_default(self):
+        assert self._fresh_import_cap("-400") == "500"
+
+
+class TestRecallTruncation:
+    def test_default_cap_truncates_at_500(self, temp_db):
+        beam = BeamMemory(session_id="cap", db_path=temp_db)
+        long_mem = "Alice a un passe-temps particulier " + " ".join(f"detail{n}" for n in range(120)) + " fin souvenir"
+        assert len(long_mem) > 500
+        mid = beam.remember(long_mem)
+        try:
+            res = beam.recall("passe-temps particulier detail5", top_k=10)
+            items = res if isinstance(res, list) else getattr(res, "results", [])
+            row = next((it for it in items if "passe-temps particulier" in (it.get("content") or "")), None)
+            assert row is not None
+            assert len(row["content"]) == 500
+        finally:
+            beam.conn.execute("DELETE FROM working_memory WHERE id=?", (mid,))
+            beam.conn.commit()
+
+    def test_opt_in_cap_truncates_at_raised_boundary(self, temp_db, monkeypatch):
+        # M3: content longer than the RAISED cap must truncate AT the cap
+        # (a test with content between 500 and 4000 would pass even if the
+        # truncation were completely broken).
+        monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 4000)
+        beam = BeamMemory(session_id="cap2", db_path=temp_db)
+        long_mem = "Alice a un passe-temps particulier " + " ".join(f"detail{n}" for n in range(500)) + " fin souvenir"
+        assert len(long_mem) > 4000
+        mid = beam.remember(long_mem)
+        try:
+            res = beam.recall("passe-temps particulier detail5", top_k=10)
+            items = res if isinstance(res, list) else getattr(res, "results", [])
+            row = next((it for it in items if "passe-temps particulier" in (it.get("content") or "")), None)
+            assert row is not None
+            assert len(row["content"]) == 4000
+        finally:
+            beam.conn.execute("DELETE FROM working_memory WHERE id=?", (mid,))
+            beam.conn.commit()
+
+
+class TestBoundaryEnforcement:
+    """P1: the cap must hold at the shared public-result boundary — every
+    recall() exit path (linear, polyphonic, MEMORIA supplements, fact merge)
+    — not only on the six linear producer slices."""
+
+    LONG = "boundary cap probe content " + " ".join(f"seg{n}" for n in range(120)) + " end"
+
+    def _seed(self, beam, monkeypatch, cap=100):
+        monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", cap)
+        assert len(self.LONG) > cap
+        beam.remember(self.LONG, source="conversation", dedupe=False)
+
+    def test_polyphonic_mapper_boundary(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="p1", db_path=temp_db)
+        self._seed(beam, monkeypatch)
+        mid = beam.conn.execute(
+            "SELECT id FROM working_memory ORDER BY rowid DESC LIMIT 1"
+        ).fetchone()["id"]
+        row = beam.conn.execute(
+            "SELECT id, content, source, timestamp, session_id, importance,"
+            " recall_count, last_recalled, scope, author_id, author_type,"
+            " channel_id, veracity, memory_type FROM working_memory WHERE id = ?",
+            (mid,),
+        ).fetchone()
+        d = beam._polyphonic_row_to_dict(row, tier_label="working")
+        assert len(d["content"]) == 100
+
+    def test_polyphonic_fetch_boundary(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="p1f", db_path=temp_db)
+        self._seed(beam, monkeypatch)
+        mid = beam.conn.execute(
+            "SELECT id FROM working_memory ORDER BY rowid DESC LIMIT 1"
+        ).fetchone()["id"]
+        d = beam._fetch_polyphonic_row(beam.conn.cursor(), mid)
+        assert d is not None
+        assert len(d["content"]) == 100
+
+    def test_fact_merge_boundary(self, temp_db, monkeypatch):
+        # The fact-voice merge path shares the boundary via recall()'s
+        # return; force it by enabling fact recall and confirming no
+        # over-cap content leaves recall() even when facts are long.
+        monkeypatch.setenv("MNEMOSYNE_FACT_RECALL_ENABLED", "1")
+        beam = BeamMemory(session_id="p3", db_path=temp_db)
+        self._seed(beam, monkeypatch)
+        res = beam.recall("boundary cap probe content", top_k=10)
+        items = res if isinstance(res, list) else getattr(res, "results", [])
+        assert items
+        assert all(len(it.get("content", "")) <= 100 for it in items)
+
+    def test_recall_explain_boundary(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="p4", db_path=temp_db)
+        self._seed(beam, monkeypatch)
+        res = beam.recall("boundary cap probe content", top_k=10, explain=True)
+        results = res["results"]
+        assert results
+        assert all(len(it["content"]) <= 100 for it in results)
+
+    def test_boundary_function_tolerates_non_results(self):
+        # Contract: the boundary is a no-op on non-list payloads (defensive;
+        # recall never returns these, but the helper must not crash if the
+        # producers change shape).
+        assert beam_module._cap_recall_results(None) is None
+        assert beam_module._cap_recall_results("short") == "short"
+
+
+class TestEnhancedCacheIdentity:
+    def _key(self, beam, monkeypatch, cap_value):
+        monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", cap_value)
+        runtime = beam_module._cross_session_enabled()  # noqa: F841
+        from types import SimpleNamespace
+        runtime = SimpleNamespace(cross_session=False)
+        return beam._enhanced_recall_cache_key(
+            original_query="q", expanded_query="q", top_k=10, runtime=runtime,
+            use_weibull=False, use_mmr=False, use_intent=False, use_synonyms=False,
+            use_associative=False, associative_depth=0, mmr_lambda=0.5,
+            recall_kwargs={},
+        )
+
+    def test_cap_changes_cache_identity(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="cache", db_path=temp_db)
+        k500 = self._key(beam, monkeypatch, 500)
+        k4000 = self._key(beam, monkeypatch, 4000)
+        assert k500 != k4000, "entries under different caps must not cross-hit"
+
+
+class TestFunctionalCapBoundaries:
+    """Exercise public recall boundaries for polyphonic, fact-merge and
+    persisted-cache paths, rather than only their internal helpers."""
+
+    def _long_content(self, n: int) -> str:
+        return ("x" * 10 + " ") * (n // 11 + 1)
+
+    def test_polyphonic_recall_capped_normal_and_explain(self, temp_db, monkeypatch):
+        # Stub the engine seam with over-cap content; the boundary at
+        # recall() must cap the returned payload in BOTH modes.
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s-cap", db_path=temp_db)
+
+        # Real rows (hydration by memory_id must find them); the raw stored
+        # content exceeds the cap, so a faithful pipeline output is over-cap
+        # BEFORE the boundary.
+        raw = self._long_content(918)
+        real_ids = [
+            beam.remember(raw + f" part{i}", source="conversation")
+            for i in range(3)
+        ]
+
+        class _FakeEngine:
+            def recall(self, query, query_embedding=None, top_k=10, **kw):
+                from mnemosyne.core.polyphonic_recall import PolyphonicResult
+                return [
+                    PolyphonicResult(
+                        memory_id=rid, content=raw + f" part{i}",
+                        combined_score=0.9 - i * 0.01,
+                        voice_scores={"vector": 0.9 - i * 0.01},
+                        metadata={},
+                    )
+                    for i, rid in enumerate(real_ids)
+                ]
+
+        monkeypatch.setattr(
+            beam, "_get_polyphonic_engine", lambda: _FakeEngine()
+        )
+
+        results = beam.recall("long content probe", top_k=10)
+        assert results, "polyphonic recall must return the stubbed rows"
+        for r in results:
+            assert len(r["content"]) <= beam_module.RECALL_CONTENT_CAP, (
+                "polyphonic normal-mode payload must respect the cap"
+            )
+
+        explained = beam.recall("long content probe", top_k=10, explain=True)
+        payload = explained if isinstance(explained, dict) else {"results": explained}
+        items = payload.get("results") or []
+        assert items, "explain mode must still surface the rows"
+        for r in items:
+            content = r.get("content", "") if isinstance(r, dict) else getattr(r, "content", "")
+            assert len(content) <= beam_module.RECALL_CONTENT_CAP, (
+                "polyphonic explain-mode payload must respect the cap"
+            )
+
+    def test_fact_merge_capped_with_tier(self, temp_db, monkeypatch):
+        # Real path: facts table + MNEMOSYNE_FACT_RECALL_ENABLED=1; the row
+        # must come back tier='fact' AND capped.
+        monkeypatch.setenv("MNEMOSYNE_FACT_RECALL_ENABLED", "1")
+        beam = BeamMemory(session_id="s-cap", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO facts (fact_id, session_id, subject, predicate, object,"
+            " timestamp, confidence) VALUES (?,?,?,?,?,?,?)",
+            (
+                "fact-cap-1", beam.session_id, "Alice", "works at",
+                "BigCorp " + "detail " * 120,
+                "2026-09-05T12:00:00", 0.9,
+            ),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("where does Alice work", top_k=10)
+        fact_rows = [r for r in results if r.get("tier") == "fact"]
+        assert fact_rows, "fact merge must surface the seeded row with tier='fact'"
+        for r in fact_rows:
+            assert len(r["content"]) <= beam_module.RECALL_CONTENT_CAP
+
+    def test_persisted_cache_rejects_foreign_cap_entry(self, temp_db, monkeypatch):
+        # Cap A entry persisted, cap B query on the same DB: key identity
+        # must MISS (not serve the A entry), and the served content follows
+        # cap B. The cache key reads the module attribute at call time.
+        monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+        monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 5000)
+        beam_a = BeamMemory(session_id="s-cap", db_path=temp_db)
+        # Content must lexically match the query: recall legitimately
+        # returns [] for non-matching stores, which would make the cap
+        # assertions below vacuous.
+        matching = (
+            "cap identity probe notes: " + self._long_content(2000)
+        )
+        beam_a.remember(matching, source="conversation")
+        warm = beam_a.recall_enhanced("cap identity probe", top_k=5)
+        warm_results = warm.get("results") if isinstance(warm, dict) else warm
+        assert warm_results, (
+            "warm call must return the matching row — an empty warm result "
+            "proves nothing about the cache"
+        )
+
+        cache_path = temp_db.parent / "query_cache.db"
+        assert cache_path.exists(), (
+            "warming recall_enhanced must persist query_cache.db — without "
+            "this assertion the test passes vacuously (no cache involved)"
+        )
+
+        monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 100)
+        beam_b = BeamMemory(session_id="s-cap", db_path=temp_db)
+        out_b = beam_b.recall_enhanced("cap identity probe", top_k=5)
+        results = out_b.get("results") if isinstance(out_b, dict) else out_b
+        assert results, (
+            "cap-B call must return the matching row (cache MISS by cap "
+            "identity, recomputed at cap B)"
+        )
+        for r in results:
+            assert len(r["content"]) <= 100, (
+                "a persisted cap-A entry must never be served under cap B; "
+                "content must be re-capped at B"
+            )
+
+
+@pytest.mark.parametrize("cap", [1, 500, 4000])
+def test_enhanced_associative_cold_and_cached_content_cap(temp_db, monkeypatch, cap):
+    from mnemosyne.core.episodic_graph import GraphEdge
+
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", cap)
+    memory = BeamMemory(session_id="cap-graph", db_path=temp_db)
+    try:
+        seed = memory.remember("quasar observatory " + "detail " * 100, dedupe=False)
+        target = memory.remember("unrelated heliotrope", dedupe=False)
+        edge_type = "rel" if cap == 1 else "related-" + "é星" * cap
+        raw_content = f"[Associative: {edge_type}]"
+        assert len(raw_content) > cap
+        assert memory.episodic_graph is not None
+        memory.episodic_graph.add_edge(
+            GraphEdge(seed, target, edge_type, 0.8, "2026-01-01T00:00:00")
+        )
+        def query():
+            return memory.recall_enhanced(
+                "quasar observatory", top_k=1, use_associative=True,
+                use_synonyms=False, use_weibull=False, use_mmr=False, use_intent=False,
+            )
+
+        cold = query()
+        assert {r["id"] for r in cold} == {seed, target}
+        assoc = next(r for r in cold if r["tier"] == "associative")
+        assert assoc["content"] == raw_content[:cap]
+        assert assoc["connecting_edge"] == edge_type
+        assert all(len(r["content"]) <= cap for r in cold)
+
+        hits = []
+        original_get = memory._query_cache.get_opaque
+
+        def get_cached(key):
+            cached = original_get(key)
+            hits.append((key, cached))
+            return cached
+
+        def no_recompute(*args, **kwargs):
+            pytest.fail("warm recall must use the real persisted cache")
+
+        monkeypatch.setattr(memory._query_cache, "get_opaque", get_cached)
+        monkeypatch.setattr(memory, "recall", no_recompute)
+        warm = query()
+        assert warm == cold
+        assert hits and hits[-1][1] == cold
+        assert temp_db.with_name("query_cache.db").exists()
+        # Inspect the serialized payload independently of the public hit cap.
+        assert original_get(hits[-1][0]) == cold
+
+        # A same-key oversized entry must also respect the public boundary.
+        oversized = [dict(row, content="é星" * (cap + 1)) for row in cold]
+        memory._query_cache.put_opaque(hits[-1][0], oversized)
+        expected = [dict(row, content=row["content"][:cap]) for row in oversized]
+        assert query() == expected
+    finally:
+        memory.conn.close()
+
+
+@pytest.mark.parametrize("source", ["raw", "consolidated"])
+def test_direct_fact_recall_respects_content_cap(temp_db, monkeypatch, source):
+    """The public fact_recall surface must share the recall content bound."""
+    monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 80)
+    memory = BeamMemory(session_id="fact-cap", db_path=temp_db)
+    subject = "Capstone"
+    predicate = "records"
+    obj = "boundary " + "detail " * 80
+    try:
+        if source == "raw":
+            memory.conn.execute(
+                "INSERT INTO facts (fact_id, session_id, subject, predicate, object, "
+                "timestamp, source_msg_id, confidence) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "fact-cap-raw", memory.session_id, subject, predicate, obj,
+                    "2026-01-01T00:00:00", "source-1", 0.9,
+                ),
+            )
+        else:
+            memory.conn.execute(
+                "INSERT INTO consolidated_facts "
+                "(id, subject, predicate, object, confidence, mention_count, "
+                "first_seen, last_seen, sources_json, veracity) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "fact-cap-consolidated", subject, predicate, obj, 0.9, 1,
+                    "2026-01-01T00:00:00", "2026-01-01T00:00:00", "[]", "stated",
+                ),
+            )
+        memory.conn.commit()
+        results = memory.fact_recall("capstone", top_k=10)
+        assert len(results) == 1
+        assert results[0]["content"] == f"{subject} {predicate} {obj}"[:80]
+    finally:
+        memory.conn.close()
+
+
+def test_shmr_reflect_receives_capped_fact_recall_content(temp_db, monkeypatch):
+    """SHMR's automatic fact retrieval must not re-expose an over-cap fact."""
+    from mnemosyne.core import shmr
+
+    monkeypatch.setattr(beam_module, "RECALL_CONTENT_CAP", 80)
+    memory = BeamMemory(session_id="fact-cap-shmr", db_path=temp_db)
+    obj = "private-tail-sentinel " + "detail " * 80
+    memory.conn.execute(
+        "INSERT INTO facts (fact_id, session_id, subject, predicate, object, "
+        "timestamp, source_msg_id, confidence) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "fact-cap-shmr", memory.session_id, "Capstone", "records", obj,
+            "2026-01-01T00:00:00", "source-2", 0.9,
+        ),
+    )
+    memory.conn.commit()
+    prompts = []
+
+    def capture(prompt):
+        prompts.append(prompt)
+        return "A sufficiently long synthesized answer."
+
+    monkeypatch.setattr(shmr, "_call_llm", capture)
+    try:
+        assert shmr.reflect(memory, "capstone")
+        assert len(prompts) == 1
+        assert f"Capstone records {obj}"[:80] in prompts[0]
+        assert "detail detail detail detail detail detail detail detail" not in prompts[0]
+    finally:
+        memory.conn.close()

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -76,26 +76,27 @@ def _close_memory(memory: BeamMemory | None) -> None:
         memory.conn.close()
 
 
+@pytest.mark.parametrize("old_version", [6, 7])
 def test_staged_fts_candidate_version_bump_invalidates_old_entries(
-    enhanced, monkeypatch, tmp_path: Path
+    enhanced, monkeypatch, tmp_path: Path, old_version
 ):
     """#896 regression: staged FTS candidate membership/order changed.
 
-    An opaque entry made under version 6 can contain the old candidate set, so
-    version 7 must produce a distinct digest and execute the updated pipeline.
+    Versions 6 and 7 predate the current candidate and content-cap contracts.
+    Version 8 must produce a distinct digest and execute the updated pipeline.
     The ``v2:`` key prefix remains fixed for QueryCache's opaque-key path.
     """
     memory, calls = enhanced
-    assert memory._ENHANCED_RECALL_CACHE_VERSION == 7
+    assert memory._ENHANCED_RECALL_CACHE_VERSION == 8
 
     # Warm the persistent cache under the old candidate-selection version.
     with monkeypatch.context() as ctx:
-        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 6)
+        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", old_version)
         stale = _call(memory, "alpha query")
     assert len(calls) == 1
     stale_id = stale[0]["id"]
 
-    # The current-version digest differs from the stale v5 key: cache miss.
+    # The current-version digest differs from the stale version key: cache miss.
     fresh = _call(memory, "alpha query")
     assert len(calls) == 2  # base recall ran; the stale entry was not reused
     assert not any(r.get("id") == stale_id for r in fresh)

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -130,18 +130,19 @@ def test_unreadable_marker_bypasses_enhanced_cache_without_log_spam(
     )
 
 
-@pytest.mark.parametrize("previous_version", [6, 7])
-def test_cache_version_bump_invalidates_staged_and_admission_entries(
+@pytest.mark.parametrize("previous_version", [6, 7, 8])
+def test_cache_version_bump_invalidates_prior_candidate_and_cap_entries(
     enhanced, monkeypatch, tmp_path: Path, previous_version: int
 ):
-    """Both prior cache generations miss under the admission algorithm.
+    """Every prior cache generation misses under the content-cap contract.
 
-    Version 6 predates staged FTS candidate selection; version 7 is current
-    main before #911's admission/ranking change. The ``v2:`` key prefix stays
-    fixed for QueryCache's opaque-key path.
+    Version 6 predates staged FTS candidate selection, version 7 predates
+    vector admission/ranking, and version 8 is current main before the cap
+    becomes cache material. The ``v2:`` key prefix stays fixed for
+    QueryCache's opaque-key path.
     """
     memory, calls = enhanced
-    assert memory._ENHANCED_RECALL_CACHE_VERSION == 8
+    assert memory._ENHANCED_RECALL_CACHE_VERSION == 9
 
     with monkeypatch.context() as ctx:
         ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", previous_version)
@@ -149,7 +150,7 @@ def test_cache_version_bump_invalidates_staged_and_admission_entries(
     assert len(calls) == 1
     stale_id = stale[0]["id"]
 
-    # The current-version digest differs from either stale key: cache miss.
+    # The current-version digest differs from every stale key: cache miss.
     fresh = _call(memory, "alpha query")
     assert len(calls) == 2  # base recall ran; the stale entry was not reused
     assert not any(r.get("id") == stale_id for r in fresh)


### PR DESCRIPTION
## Summary

Make the per-result recall `content` limit configurable while keeping the shipped **500-character default**.

- `MNEMOSYNE_RECALL_CONTENT_CAP` accepts a positive integer at import time. Unset, empty, invalid and non-positive values fall back to 500.
- Apply the cap at every public recall boundary, including direct `fact_recall()`, linear, polyphonic, fact-merge and explain results.
- Cap enhanced associative additions before cache persistence/return and enforce the boundary on cache hits.
- Include the cap in enhanced-recall cache identity. This branch increments current main's cache version from **7 to 8**.
- Leave stored records unchanged; this controls returned `content`, not full-record inspection or total response bytes.

For example, `MNEMOSYNE_RECALL_CONTENT_CAP=4000` explicitly opts into a larger limit. It is **not** the default.

## Maintainer follow-up

- Direct `BeamMemory.fact_recall()` now applies the shared cap after score ordering and `top_k`, covering both raw and consolidated fact stores.
- Direct over-cap regressions cover both stores; SHMR's automatic fact retrieval is verified not to receive the uncapped tail.
- The shipped-default mutation test copies only `mnemosyne/`, excludes developer `.venv` data, and verifies the scratch import path.
- No vector-admission environment scrub or cross-PR version coordination. Zero is covered through direct parsing and a fresh subprocess import.

## Current revision

Based on main `8df6af2` after #917 merged. Main has cache version 7; this PR uses **8**. Persistent-cache regressions reject entries from versions 6 and 7 while retaining cold/warm cache-hit behavior and the opaque `v2:` key prefix.

The rebase reuses main's positive-integer parser unchanged. Conflict budgets, sleep atomicity and postcommit cache behavior remain unchanged. The public default is still 500.

## Verification at `d692abe`

One logical commit on main `8df6af2`, validated with unchanged source/tree/diff.

- Full core suite: **4060 passed, 6 skipped, 7 subtests passed in 495.98s (0:08:15)**.
- Full provider suite: **465 passed, 1 skipped in 85.64s (0:01:25)**.
- Real Python 3.10 focused checks: **175 passed in 47.20s**.
- Focused cap/cache/conflict/fact/SHMR battery: **177 passed**.
- Nine independent behavioral mutations caught, including direct fact output, both enhanced-cache guards, copy scope, zero/default parsing, cap identity, missing version bump and missing version hashing; controls passed.
- Ruff `F,RUF022` and `git diff --check`: passed. No test-file exclusions; environmental skips remain explicit in receipts.

GitHub CI, CLA and maintainer approval are separate exact-head gates. No deployment, historical rewrite or release was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds configurable recall-result content capping through `MNEMOSYNE_RECALL_CONTENT_CAP`.

- Retains the shipped 500-character default.
- Falls back to 500 for unset, empty, invalid, or non-positive values.
- Applies the cap across BEAM, polyphonic, fact-merge, explain, enhanced associative, direct `fact_recall()`, SHMR, mapper, fetch, and cache-hit paths.
- Includes the resolved cap in enhanced-recall cache identity.
- Increases the enhanced-recall cache version to 9.
- Leaves stored records unchanged.

## Architectural impact

This change strengthens the BEAM retrieval boundary across working-memory, episodic, and fact-backed results. It does not change tier selection, retrieval strategies, consolidation, veracity processing, or the sync layer.

The cap limits content exposed to callers and SHMR agent prompts without changing persisted memory. This improves privacy and preserves the local-first design. No remote service, telemetry, or data-sharing path is added.

Hermes, MCP, and CLI surfaces retain their existing contracts. They receive bounded content through existing core recall paths.

Cache isolation prevents results created under one cap from being served under another cap. The cache-version bump rejects older enhanced-recall generations. This is the right call for correctness, privacy, and maintainability.

Tests cover configuration validation, all recall boundaries, cache identity and persistence, direct fact recall, SHMR retrieval, cache invalidation, and protection against accidental changes to the shipped default. Benchmark methodology remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

