### PR TITLE
fix(#914): per-write author identity for Hermes provider memory writes

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1898,6 +1898,46 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         return "default"
 
+    def _resolve_author_identity(self) -> dict:
+        """Resolve author identity for memory writes (issue #914).
+
+        Precedence (matches the MCP path in mnemosyne.mcp_tools._create_instance):
+        1. agent_identity kwarg (explicit, from Hermes)
+        2. MNEMOSYNE_AUTHOR_ID / MNEMOSYNE_AUTHOR_TYPE env vars
+        3. No identity -> empty dict (constructors called without author
+           kwargs, preserving the legacy NULL-author behavior exactly).
+
+        'primary' is a generic identity, not a specific author, and is
+        excluded the same way _resolve_profile_bank treats it.
+        """
+        identity = getattr(self, "_agent_identity", None) or ""
+        if identity and identity.lower() not in ("primary", "default", "none", ""):
+            result = {"author_id": identity}
+            author_type = os.environ.get("MNEMOSYNE_AUTHOR_TYPE")
+            if author_type:
+                result["author_type"] = author_type
+            return result
+
+        env_author = os.environ.get("MNEMOSYNE_AUTHOR_ID")
+        if env_author:
+            result = {"author_id": env_author}
+            author_type = os.environ.get("MNEMOSYNE_AUTHOR_TYPE")
+            if author_type:
+                result["author_type"] = author_type
+            return result
+
+        return {}
+
+    def _write_identity_kwargs(self) -> dict:
+        """Per-write author identity kwargs for remember() calls (issue #914).
+
+        Narrow per-write identity path per the #914 design note: identity is
+        attached at the WRITE, never by mutating the Beam's read identity
+        (self.author_id), because recall author-scoping keys off that field
+        and setting it would bypass session/channel scoping in prefetch.
+        """
+        return self._resolve_author_identity()
+
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
         # C27: clear stale state from any prior init attempt so a re-init
@@ -2530,6 +2570,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     importance=0.85,
                     scope="global",
                     veracity="stated",
+                    **self._write_identity_kwargs(),
                 )
                 break  # One identity memory per turn
 
@@ -2765,6 +2806,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             extract=extract,
             metadata=metadata,
             veracity=veracity,
+            **self._write_identity_kwargs(),
         )
         self._audit_event(
             "remember", memory_id=memory_id, bank="private",
@@ -3397,6 +3439,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     veracity=clamp_veracity(
                         payload.get("veracity"), context="mnemosyne_apply_pending"
                     ),
+                    **self._write_identity_kwargs(),
                 )
                 record_path.unlink(missing_ok=True)
                 applied.append({"id": pid, "memory_id": memory_id})
@@ -3826,6 +3869,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 source=f"builtin_memory_{target}",
                 importance=0.7 if target == "user" else 0.5,
                 scope=scope,
+                **self._write_identity_kwargs(),
             )
         except Exception as e:
             logger.debug("Mnemosyne mirror write failed: %s", e)

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -1337,6 +1337,48 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         return "default"
 
+    def _resolve_author_identity(self) -> dict:
+        """Resolve author identity for memory writes (issue #914).
+
+        Precedence (matches the MCP path in mnemosyne.mcp_tools._create_instance):
+        1. agent_identity kwarg (explicit, from Hermes)
+        2. MNEMOSYNE_AUTHOR_ID / MNEMOSYNE_AUTHOR_TYPE env vars
+        3. No identity -> empty dict (constructors called without author
+           kwargs, preserving the legacy NULL-author behavior exactly).
+
+        'primary' is a generic identity, not a specific author, and is
+        excluded the same way _resolve_profile_bank treats it. Kept in strict
+        parity with hermes_memory_provider.MnemosyneMemoryProvider.
+        """
+        identity = getattr(self, "_agent_identity", None) or ""
+        if identity and identity.lower() not in ("primary", "default", "none", ""):
+            result = {"author_id": identity}
+            author_type = os.environ.get("MNEMOSYNE_AUTHOR_TYPE")
+            if author_type:
+                result["author_type"] = author_type
+            return result
+
+        env_author = os.environ.get("MNEMOSYNE_AUTHOR_ID")
+        if env_author:
+            result = {"author_id": env_author}
+            author_type = os.environ.get("MNEMOSYNE_AUTHOR_TYPE")
+            if author_type:
+                result["author_type"] = author_type
+            return result
+
+        return {}
+
+    def _write_identity_kwargs(self) -> dict:
+        """Per-write author identity kwargs for remember() calls (issue #914).
+
+        Narrow per-write identity path per the #914 design note: identity is
+        attached at the WRITE, never by mutating the Beam's read identity
+        (self.author_id), because recall author-scoping keys off that field
+        and setting it would bypass session/channel scoping in prefetch.
+        Kept in strict parity with hermes_memory_provider.
+        """
+        return self._resolve_author_identity()
+
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
         with self._ensure_beam_access_lock():
@@ -1923,6 +1965,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     importance=0.85,
                     scope="global",
                     veracity="stated",
+                    **self._write_identity_kwargs(),
                 )
                 break  # One identity memory per turn
 
@@ -2209,6 +2252,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             extract=extract,
             metadata=metadata,
             veracity=veracity,
+            **self._write_identity_kwargs(),
         )
         self._audit_event(
             "remember", memory_id=memory_id, bank="private",
@@ -2838,6 +2882,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     extract=bool(p.get("extract", False)),
                     metadata=p.get("metadata"),
                     veracity=clamp_veracity(p.get("veracity"), context="apply_pending"),
+                    **self._write_identity_kwargs(),
                 )
                 rp.unlink(missing_ok=True)
                 applied.append({"id": pid, "memory_id": mid})

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4418,7 +4418,9 @@ class BeamMemory:
                  veracity: str = "unknown",
                  trust_tier: str = None,
                  memory_type: str = None,
-                 dedupe: bool = True) -> str:
+                 dedupe: bool = True,
+                 author_id: str = None,
+                 author_type: str = None) -> str:
         """Store into working_memory. Deduplicates exact content matches.
 
         When called from the legacy-compatible Mnemosyne.remember() path,
@@ -4439,6 +4441,11 @@ class BeamMemory:
                 and store as triples. Default False.
             veracity: Confidence level -- 'stated', 'inferred', 'tool', 'imported', 'unknown'.
                 Non-canonical labels are clamped to 'unknown' with a WARNING
+            author_id: Per-write author identity. When provided, overrides
+                self.author_id for THIS write only (issue #914). The instance
+                read identity (self.author_id, used by recall author-scoping)
+                is never mutated. None falls back to self.author_id.
+            author_type: Per-write author type, same override semantics.
                 (mirrors the C12.b clamp at the hermes_memory_provider boundary).
             memory_type: Optional explicit MemoryType value (e.g. 'artifact').
                 Overrides the content classifier entirely -- the classifier is
@@ -4494,6 +4501,12 @@ class BeamMemory:
         # content does not say. An unrecognized label degrades to
         # classification rather than to NULL.
         memory_type = _clamp_memory_type(memory_type)
+        # --- Per-write author identity (issue #914) ---
+        # Resolve once: per-write args override the instance identity for
+        # THIS write only. self.author_id (read identity, consulted by
+        # recall author-scoping) is never mutated.
+        _write_author_id = author_id if author_id is not None else self.author_id
+        _write_author_type = author_type if author_type is not None else self.author_type
         if memory_type is None and classify_memory is not None:
             try:
                 result = classify_memory(content)
@@ -4536,7 +4549,7 @@ class BeamMemory:
                 WHERE id = ? AND session_id = ?
             """, (importance, datetime.now(timezone.utc).replace(tzinfo=None).isoformat(), source,
                   valid_until, scope,
-                  self.author_id, self.author_type, self.channel_id,
+                  _write_author_id, _write_author_type, self.channel_id,
                   memory_type,
                   veracity, veracity,
                   trust_tier,
@@ -4583,7 +4596,7 @@ class BeamMemory:
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (memory_id, content, source, timestamp, self.session_id, importance,
               json.dumps(metadata or {}), valid_until, scope,
-              self.author_id, self.author_type, self.channel_id, veracity, memory_type, trust_tier))
+              _write_author_id, _write_author_type, self.channel_id, veracity, memory_type, trust_tier))
         self.conn.commit()
         try:
             self._trim_working_memory()

--- a/tests/test_hermes_provider_author_identity.py
+++ b/tests/test_hermes_provider_author_identity.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for issue #914: Hermes provider writes never carry author_id.
+
+Expected fix (per maintainer design note on #914): a NARROW PER-WRITE identity
+path. Identity resolution precedence: agent_identity kwarg > MNEMOSYNE_AUTHOR_ID
+env > no identity. The identity is attached to WRITE calls via remember()'s
+per-write author_id/author_type params — the Beam constructor's read identity
+is deliberately NOT set, because recall author-scoping keys off it and setting
+it would bypass session/channel scoping in prefetch (the exact regression the
+thread-isolation suite guards against).
+
+These tests use a REAL BeamMemory in a temp dir (matching the repo's own
+shared-crud test conventions) rather than mocking the beam, so they exercise
+the actual write path end to end.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _provider(tmp_path: Path, monkeypatch, agent_identity="sphinx"):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / (agent_identity or "main")
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+    monkeypatch.delenv("MNEMOSYNE_AUTHOR_ID", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_AUTHOR_TYPE", raising=False)
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="s1",
+        hermes_home=str(hermes_home),
+        agent_identity=agent_identity,
+    )
+    assert provider._beam is not None
+    return provider
+
+
+def _call(provider, name, args):
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+class TestWriteIdentityResolution:
+    """_resolve_author_identity precedence contract."""
+
+    def test_kwarg_identity_wins(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_AUTHOR_ID", "env-agent")
+        provider = MnemosyneMemoryProvider()
+        provider._agent_identity = "sphinx"
+        assert provider._resolve_author_identity() == {"author_id": "sphinx"}
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_AUTHOR_ID", "env-agent")
+        monkeypatch.setenv("MNEMOSYNE_AUTHOR_TYPE", "agent")
+        provider = MnemosyneMemoryProvider()
+        provider._agent_identity = ""
+        assert provider._resolve_author_identity() == {
+            "author_id": "env-agent", "author_type": "agent",
+        }
+
+    def test_primary_is_generic(self, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_AUTHOR_ID", raising=False)
+        provider = MnemosyneMemoryProvider()
+        provider._agent_identity = "primary"
+        assert provider._resolve_author_identity() == {}
+
+    def test_no_identity_empty(self, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_AUTHOR_ID", raising=False)
+        provider = MnemosyneMemoryProvider()
+        provider._agent_identity = ""
+        assert provider._resolve_author_identity() == {}
+
+
+class TestConstructorsUnchanged:
+    """Read identity must stay untouched: the beam's author_id stays None."""
+
+    def test_beam_read_identity_is_none(self, tmp_path, monkeypatch):
+        provider = _provider(tmp_path, monkeypatch, agent_identity="sphinx")
+        assert provider._beam.author_id is None
+        assert provider._beam.author_type is None
+
+
+class TestRememberCarriesIdentity:
+    """mnemosyne_remember stores rows with the resolved author, per-write."""
+
+    def test_remember_row_has_author(self, tmp_path, monkeypatch):
+        provider = _provider(tmp_path, monkeypatch, agent_identity="sphinx")
+        result = _call(provider, "mnemosyne_remember", {
+            "content": "james prefers tea", "scope": "session",
+        })
+        assert result["status"] == "stored"
+        row = provider._beam.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content = 'james prefers tea'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "sphinx"
+        # Read identity STILL untouched after a write
+        assert provider._beam.author_id is None
+
+    def test_remember_without_identity_stores_null(self, tmp_path, monkeypatch):
+        provider = _provider(tmp_path, monkeypatch, agent_identity="")
+        result = _call(provider, "mnemosyne_remember", {
+            "content": "plain note", "scope": "session",
+        })
+        assert result["status"] == "stored"
+        row = provider._beam.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content = 'plain note'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] is None
+
+    def test_env_author_used_when_no_kwarg(self, tmp_path, monkeypatch):
+        provider = _provider(tmp_path, monkeypatch, agent_identity="")
+        monkeypatch.setenv("MNEMOSYNE_AUTHOR_ID", "env-agent")
+        result = _call(provider, "mnemosyne_remember", {
+            "content": "env authored", "scope": "session",
+        })
+        assert result["status"] == "stored"
+        row = provider._beam.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content = 'env authored'"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "env-agent"

--- a/tests/test_remember_per_write_identity.py
+++ b/tests/test_remember_per_write_identity.py
@@ -1,0 +1,87 @@
+"""
+Core per-write author identity tests (issue #914 companion).
+
+Contract: remember() accepts optional author_id/author_type that override the
+instance identity for THAT write only. Read identity (self.author_id, used by
+recall author-scoping) is never mutated. None/omitted -> falls back to
+self.author_id (exact legacy behavior).
+"""
+
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def beam():
+    tmpdir = Path(tempfile.mkdtemp())
+    old = os.environ.get("MNEMOSYNE_DATA_DIR")
+    os.environ["MNEMOSYNE_DATA_DIR"] = str(tmpdir)
+    bm = BeamMemory(session_id="t")
+    yield bm
+    if old:
+        os.environ["MNEMOSYNE_DATA_DIR"] = old
+    else:
+        os.environ.pop("MNEMOSYNE_DATA_DIR", None)
+
+
+class TestPerWriteAuthorIdentity:
+    def test_per_write_author_id_stored(self, beam):
+        """remember(author_id=...) writes that author, instance stays None."""
+        beam.remember("fact one", author_id="agent-x")
+        row = beam.conn.execute(
+            "SELECT author_id, author_type FROM working_memory WHERE content='fact one'"
+        ).fetchone()
+        assert row[0] == "agent-x"
+        assert beam.author_id is None  # read identity untouched
+
+    def test_per_write_falls_back_to_instance(self, beam):
+        """No per-write author -> instance identity (legacy behavior)."""
+        bm = BeamMemory(session_id="t", author_id="inst-agent")
+        bm.remember("fact two")
+        row = bm.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content='fact two'"
+        ).fetchone()
+        assert row[0] == "inst-agent"
+
+    def test_per_write_overrides_instance(self, beam):
+        bm = BeamMemory(session_id="t", author_id="inst-agent")
+        bm.remember("fact three", author_id="other-agent")
+        row = bm.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content='fact three'"
+        ).fetchone()
+        assert row[0] == "other-agent"
+        assert bm.author_id == "inst-agent"  # instance unchanged
+
+    def test_per_write_author_type(self, beam):
+        beam.remember("fact four", author_id="agent-y", author_type="agent")
+        row = beam.conn.execute(
+            "SELECT author_id, author_type FROM working_memory WHERE content='fact four'"
+        ).fetchone()
+        assert tuple(row) == ("agent-y", "agent")
+
+    def test_dedup_update_uses_per_write_author(self, beam):
+        """Re-remembering same content with a per-write author upgrades the row."""
+        beam.remember("dup fact", author_id="first")
+        beam.remember("dup fact", author_id="second")
+        row = beam.conn.execute(
+            "SELECT author_id FROM working_memory WHERE content='dup fact'"
+        ).fetchone()
+        assert row[0] == "second"
+
+    def test_batch_per_write_author(self, beam):
+        """remember_batch items honor per-item author_id."""
+        bm = BeamMemory(session_id="t")
+        bm.remember_batch([
+            {"content": "b1", "author_id": "a1"},
+            {"content": "b2"},
+        ])
+        rows = dict(bm.conn.execute(
+            "SELECT content, author_id FROM working_memory WHERE content IN ('b1','b2')"
+        ).fetchall())
+        assert rows["b1"] == "a1"
+        assert rows["b2"] is None


### PR DESCRIPTION
## Summary

Fixes #914 (writes never carry `author_id` in the Hermes provider path).

Root cause (confirmed against main): both Hermes provider surfaces construct their `Mnemosyne`/`BeamMemory` instances without author identity, so every write stores NULL `author_id`. The documented `MNEMOSYNE_AUTHOR_ID` env var was only consulted in the recall path (`_prefetch_bank`), never for writes — unlike the MCP path, which reads all three identity env vars into the constructor correctly.

## Approach: narrow per-write identity (per the design note on #914)

Instead of constructor injection, identity is attached **at the write**:

- **Core:** `BeamMemory.remember()` accepts `author_id`/`author_type` params. `None` falls back to the instance identity (exact legacy behavior). Both the dedup-update and new-row INSERT paths use the per-write identity. Read identity (`self.author_id`, used by recall author-scoping) is never mutated.
- **Both providers, strict parity:** `hermes_memory_provider` and the standalone `integrations/hermes` surface resolve identity once (`agent_identity` kwarg > `MNEMOSYNE_AUTHOR_ID`/`_TYPE` env > none) and pass it at every `remember()` call site.
- **Constructors deliberately unchanged:** recall author-scoping keys off `Beam.author_id`; setting it would make prefetch pass a non-empty `author_id`, which triggers the `(1=1)` clause that bypasses session/channel scoping. This regression is caught by `test_prefetch_scopes_to_thread` and is why the constructor path was reverted in favor of per-write.

I evaluated constructor injection first and hit exactly that failure against the thread-isolation suite before reverting — so the per-write direction isn't just preferred, it's the one that survives the existing tests.

## Tests

New: `tests/test_remember_per_write_identity.py` (core per-write semantics: storage, instance fallback, override, dedup-update, batch per-item) and `tests/test_hermes_provider_author_identity.py` (resolution precedence, read identity untouched, end-to-end storage with a real `BeamMemory`, NULL when unresolvable, env-var fallback).

All 129 tests across the Hermes provider, shared-surface, thread-isolation, and multi-agent-identity suites pass. (Full-suite runs in my environment show ~130 preexisting failures from cross-test state pollution, identical on clean HEAD — the sync-correctness/security failures reproduce without this branch and pass in isolation.)

## Notes for review

The maintainer note on #914 also flagged provenance for pending-approval writes and sleep consolidation. Pending writes (`mnemosyne_apply_pending`) now carry identity via the same per-write path. Consolidation provenance (`self.author_id` in `consolidate_to_episodic`) is **not** touched here — it needs the row-provenance discussion from the issue thread and seemed right to keep in a focused follow-up rather than bundle into this fix.

Found while evaluating Mnemosyne as shared memory for a multi-agent Hermes deployment — the identity layer is exactly what that use case needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds per-write `author_id` and `author_type` support to `BeamMemory.remember()`.
- Applies identity to both insert and deduplication update paths without changing read identity.
- Resolves identity in Hermes from `agent_identity`, then environment variables, then no identity.
- Covers regular, batch, identity-signal, and pending-approval writes.
- Preserves thread and session scoping because `BeamMemory.author_id` remains unset for recall and prefetch.
- Keeps constructors unchanged and does not modify consolidation provenance.

## Architecture and integration impact

- Working-memory attribution now supports multi-agent writes. Episodic memory, BEAM retrieval, tiering, consolidation, veracity handling, and sync behavior remain unchanged.
- Hermes and standalone `integrations/hermes` now provide write-side identity parity with the MCP integration.
- CLI behavior is unchanged.
- The implementation preserves local-first operation. Identity resolution uses local arguments and environment variables. No remote service or new sync dependency is introduced.
- Per-write identity is the right architectural choice. It separates write attribution from read scoping and avoids privacy and retrieval regressions caused by setting the Beam read identity.
- Tests cover precedence, batching, storage, deduplication, unresolved identity, and read-identity preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->