### PR TITLE
fix(hermes): isolate sync to shared surface

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1388,6 +1388,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._memory: Optional[Any] = None
         self._beam: Optional[Any] = None
         self._surface_beam: Optional[Any] = None
+        self._sync_adapter: Optional[Any] = None
         self._shared_surface_bank = "surface"
         self._shared_surface_path: Optional[Path] = None
         # When true, mnemosyne_recall merges shared-surface results into the
@@ -1516,6 +1517,17 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Audit log initialized: %s", db_path)
         except Exception as exc:
             logger.debug("Audit log init skipped: %s", exc)
+
+    def _clear_sync_adapter(self) -> None:
+        """Drop the sync adapter that retains the surface Beam being replaced."""
+        adapter = getattr(self, "_sync_adapter", None)
+        self._sync_adapter = None
+        if adapter is None:
+            return
+        try:
+            adapter.shutdown()
+        except Exception:
+            logger.debug("Mnemosyne: could not close sync adapter", exc_info=True)
 
     def _audit_event(self, action: str, **kwargs) -> None:
         """Record an audit event. Never raises, never blocks."""
@@ -1908,6 +1920,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # _beam active, causing system_prompt_block() to report "Active"
         # and handle_tool_call() to silently write into the wrong session.
         # _init_error reset complements this for the failure-recovery case.
+        self._clear_sync_adapter()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -3868,6 +3881,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 unregister_hermes_host_llm()
             except Exception as exc:
                 logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
+        self._clear_sync_adapter()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -3875,6 +3889,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Mnemosyne: could not close wrapper", exc_info=True)
         self._memory = None
         self._beam = None
+        self._surface_beam = None
 
         # C13: decrement this instance's contribution to the module-level
         # active-provider count. ``_provider_active`` stays True if other

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1389,6 +1389,12 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._beam: Optional[Any] = None
         self._surface_beam: Optional[Any] = None
         self._sync_adapter: Optional[Any] = None
+        # Coordinates only the shared-surface Beam and adapters that retain it.
+        # Adapter construction stays outside this lock; publication validates
+        # the generation so provider reinitialization can win without caching a
+        # stale adapter.
+        self._surface_adapter_lock = threading.RLock()
+        self._surface_generation = 0
         self._shared_surface_bank = "surface"
         self._shared_surface_path: Optional[Path] = None
         # When true, mnemosyne_recall merges shared-surface results into the
@@ -1528,6 +1534,21 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             adapter.shutdown()
         except Exception:
             logger.debug("Mnemosyne: could not close sync adapter", exc_info=True)
+
+    def _ensure_surface_adapter_lock(self):
+        """Return the surface lifecycle lock, including for __new__ tests."""
+        try:
+            return self._surface_adapter_lock
+        except AttributeError:
+            return self.__dict__.setdefault(
+                "_surface_adapter_lock", threading.RLock()
+            )
+
+    def _invalidate_surface_locked(self) -> None:
+        """Invalidate adapters and their Beam as one lifecycle transition."""
+        self._clear_sync_adapter()
+        self._surface_beam = None
+        self._surface_generation = getattr(self, "_surface_generation", 0) + 1
 
     def _audit_event(self, action: str, **kwargs) -> None:
         """Record an audit event. Never raises, never blocks."""
@@ -1912,6 +1933,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
+        with self._ensure_surface_adapter_lock():
+            self._initialize_locked(session_id, **kwargs)
+
+    def _initialize_locked(self, session_id: str, **kwargs) -> None:
+        """Rebuild provider state while the surface lifecycle lock is held."""
         # C27: clear stale state from any prior init attempt so a re-init
         # returns the provider to a clean slate. _beam reset is critical
         # for the primary->skip-context re-init case (codex review finding
@@ -1920,7 +1946,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # _beam active, causing system_prompt_block() to report "Active"
         # and handle_tool_call() to silently write into the wrong session.
         # _init_error reset complements this for the failure-recovery case.
-        self._clear_sync_adapter()
+        self._invalidate_surface_locked()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -1928,7 +1954,6 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Mnemosyne: could not close prior wrapper", exc_info=True)
         self._memory = None
         self._beam = None
-        self._surface_beam = None
         self._init_error = None
 
         self._agent_context = kwargs.get("agent_context", "primary")
@@ -2700,13 +2725,32 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def _handle_sync_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
         try:
-            adapter = getattr(self, "_sync_adapter", None)
-            if adapter is None:
-                from hermes_memory_provider.sync_adapter import SyncAdapter
-                self._ensure_surface_beam()
-                adapter = SyncAdapter(self._surface_beam, {})
-                self._sync_adapter = adapter
-            return adapter.handle_tool_call(tool_name, args)
+            from hermes_memory_provider.sync_adapter import SyncAdapter
+
+            while True:
+                with self._ensure_surface_adapter_lock():
+                    adapter = getattr(self, "_sync_adapter", None)
+                    if adapter is not None:
+                        return adapter.handle_tool_call(tool_name, args)
+                    self._ensure_surface_beam_locked()
+                    surface_beam = self._surface_beam
+                    generation = getattr(self, "_surface_generation", 0)
+
+                candidate = SyncAdapter(surface_beam, {})
+                with self._ensure_surface_adapter_lock():
+                    if (
+                        generation != getattr(self, "_surface_generation", 0)
+                        or self._surface_beam is not surface_beam
+                    ):
+                        candidate.shutdown()
+                        continue
+                    adapter = getattr(self, "_sync_adapter", None)
+                    if adapter is None:
+                        adapter = candidate
+                        self._sync_adapter = adapter
+                    else:
+                        candidate.shutdown()
+                    return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:
             return json.dumps({
                 "status": "error",
@@ -2928,6 +2972,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return f"{label}: {content}"
 
     def _ensure_surface_beam(self) -> None:
+        with self._ensure_surface_adapter_lock():
+            self._ensure_surface_beam_locked()
+
+    def _ensure_surface_beam_locked(self) -> None:
         if self._surface_beam is not None:
             return
         BeamMemory = _get_beam_class()
@@ -3881,7 +3929,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 unregister_hermes_host_llm()
             except Exception as exc:
                 logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
-        self._clear_sync_adapter()
+        with self._ensure_surface_adapter_lock():
+            self._invalidate_surface_locked()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -3889,7 +3938,6 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Mnemosyne: could not close wrapper", exc_info=True)
         self._memory = None
         self._beam = None
-        self._surface_beam = None
 
         # C13: decrement this instance's contribution to the module-level
         # active-provider count. ``_provider_active`` stays True if other

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -2690,7 +2690,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             adapter = getattr(self, "_sync_adapter", None)
             if adapter is None:
                 from hermes_memory_provider.sync_adapter import SyncAdapter
-                adapter = SyncAdapter(self._beam, {})
+                self._ensure_surface_beam()
+                adapter = SyncAdapter(self._surface_beam, {})
                 self._sync_adapter = adapter
             return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:

--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -285,6 +285,13 @@ class SyncAdapter:
 
     # --- Push --------------------------------------------------------------
 
+    def _pull_cursor(self, remote: Optional[str] = None) -> str:
+        """Return the cursor persisted by SyncEngine for this pull remote."""
+        remote_url = (remote or self.remote).rstrip("/")
+        if not remote_url:
+            return ""
+        return str(self._engine._meta_get(f"last_pull_cursor_{remote_url}") or "")
+
     def _handle_push(self) -> str:
         if not self.remote:
             return json.dumps({
@@ -302,7 +309,7 @@ class SyncAdapter:
 
         push = result.get("push") or {}
         accepted = push.get("accepted", 0)
-        cursor = str(push.get("next_cursor") or "")
+        cursor = ""
         discovered = push.get("discovered") or {}
         if not accepted and not any(discovered.values()) and not push.get("batches"):
             return json.dumps({
@@ -337,7 +344,7 @@ class SyncAdapter:
             return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
         pull = result.get("pull") or {}
-        cursor = str(pull.get("next_cursor") or "")
+        cursor = self._pull_cursor(result.get("remote"))
         if (
             not pull.get("accepted")
             and not pull.get("events_fetched")
@@ -364,7 +371,7 @@ class SyncAdapter:
         if not engine:
             return json.dumps({"status": "error", "error": "No engine"})
 
-        cursor = engine._meta_get("last_sync_cursor") or ""
+        cursor = self._pull_cursor()
         device_id = getattr(engine, "device_id", "unknown")
 
         # Count local events

--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -194,6 +194,7 @@ class SyncAdapter:
                     "sync requires the dedicated global shared surface; "
                     f"expected session {_SURFACE_SESSION_ID!r}"
                 )
+            # SQLite IS NOT is null-safe, so NULL scope/session values are invalid.
             existing_rows, invalid_rows = beam.conn.execute(
                 """SELECT COUNT(*), COALESCE(SUM(
                        CASE WHEN scope IS NOT 'global' OR session_id IS NOT ? THEN 1 ELSE 0 END

--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -32,11 +32,13 @@ import os
 import threading
 import urllib.request
 import urllib.error
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_SURFACE_ID = "shared-surface-v1"
+_SURFACE_SESSION_ID = "hermes_shared_surface"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +187,26 @@ class SyncAdapter:
         try:
             from mnemosyne.core.sync import SyncEngine, SyncEncryption
 
+            beam = getattr(self._beam, "beam", self._beam)
+            session_id = getattr(beam, "session_id", None)
+            if session_id != _SURFACE_SESSION_ID:
+                raise ValueError(
+                    "sync requires the dedicated global shared surface; "
+                    f"expected session {_SURFACE_SESSION_ID!r}"
+                )
+            existing_rows, invalid_rows = beam.conn.execute(
+                """SELECT COUNT(*), COALESCE(SUM(
+                       CASE WHEN scope IS NOT 'global' OR session_id IS NOT ? THEN 1 ELSE 0 END
+                   ), 0)
+                   FROM working_memory""",
+                (_SURFACE_SESSION_ID,),
+            ).fetchone()
+            if invalid_rows:
+                raise ValueError(
+                    "sync requires a dedicated global shared surface; "
+                    "found private or foreign-session rows"
+                )
+
             encryption = None
             if self.encrypt_enabled and self.encryption_key:
                 encryption = SyncEncryption.from_config(key_source=self.encryption_key)
@@ -199,6 +221,10 @@ class SyncAdapter:
             self._engine = SyncEngine(
                 beam_instance=self._beam,
                 encryption=encryption,
+                surface_only=True,
+                surface_id=_SURFACE_ID,
+                initialize_surface=True,
+                claim_existing_surface=bool(existing_rows),
             )
             logger.info(
                 "SyncAdapter initialized: device=%s, remote=%s, encrypt=%s",
@@ -266,34 +292,30 @@ class SyncAdapter:
                 "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
             })
 
-        # Last cursor from sync_meta
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        changes = self._engine.pull_changes(since_cursor=cursor or None, limit=500)
+        result = self._engine.sync_with(
+            self.remote,
+            mode="push",
+            api_key=self.auth_token or None,
+        )
+        if result.get("errors"):
+            return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
-        events = changes.get("events", [])
-        if not events:
+        push = result.get("push") or {}
+        accepted = push.get("accepted", 0)
+        cursor = str(push.get("next_cursor") or "")
+        discovered = push.get("discovered") or {}
+        if not accepted and not any(discovered.values()) and not push.get("batches"):
             return json.dumps({
                 "status": "ok",
                 "pushed": 0,
                 "message": "No local changes to push.",
             })
 
-        # Push to remote
-        result = self._http_post("/sync/push", {"events": events})
-        if result.get("status") != "ok":
-            return json.dumps(result)
-
-        accepted = result.get("accepted", 0)
-        cursor = result.get("next_cursor") or changes.get("next_cursor") or ""
-
-        if cursor:
-            self._engine._meta_set("last_sync_cursor", cursor)
-
         return json.dumps({
             "status": "ok",
             "pushed": accepted,
-            "duplicates": result.get("duplicates", 0),
-            "conflicts": result.get("conflicts", 0),
+            "duplicates": push.get("duplicates", 0),
+            "conflicts": push.get("conflicts", 0),
             "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
         })
 
@@ -306,33 +328,32 @@ class SyncAdapter:
                 "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
             })
 
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        result = self._http_post("/sync/pull", {"since_token": cursor or None})
+        result = self._engine.sync_with(
+            self.remote,
+            mode="pull",
+            api_key=self.auth_token or None,
+        )
+        if result.get("errors"):
+            return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
-        if result.get("status") != "ok":
-            return json.dumps(result)
-
-        incoming = result.get("events", [])
-        if not incoming:
+        pull = result.get("pull") or {}
+        cursor = str(pull.get("next_cursor") or "")
+        if (
+            not pull.get("accepted")
+            and not pull.get("events_fetched")
+            and not pull.get("batches")
+        ):
             return json.dumps({
                 "status": "ok",
                 "pulled": 0,
                 "message": "No remote changes to pull.",
             })
 
-        # Apply locally
-        push_result = self._engine.push_changes(incoming)
-        accepted = push_result.get("accepted", 0)
-        cursor = result.get("next_cursor") or ""
-
-        if cursor:
-            self._engine._meta_set("last_sync_cursor", cursor)
-
         return json.dumps({
             "status": "ok",
-            "pulled": accepted,
-            "duplicates": push_result.get("duplicates", 0),
-            "conflicts": push_result.get("conflicts", 0),
+            "pulled": pull.get("accepted", 0),
+            "duplicates": pull.get("duplicates", 0),
+            "conflicts": pull.get("conflicts", 0),
             "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
         })
 

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -2139,7 +2139,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             adapter = getattr(self, "_provider_sync_adapter", None)
             if adapter is None:
                 from mnemosyne_hermes.sync_adapter import SyncAdapter
-                adapter = SyncAdapter(self._beam, {})
+                self._ensure_surface_beam()
+                adapter = SyncAdapter(self._surface_beam, {})
                 self._provider_sync_adapter = adapter
             return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:
@@ -3540,7 +3541,10 @@ def _get_sync_handler(tool_name: str):
         if _sync_adapter is None:
             try:
                 from mnemosyne_hermes.sync_adapter import SyncAdapter as SA
-                _sync_adapter = SA(None)  # config resolved from env
+                if _provider is None:
+                    raise RuntimeError("Mnemosyne provider is not initialized")
+                _provider._ensure_surface_beam()
+                _sync_adapter = SA(_provider._surface_beam)
             except Exception:
                 return json.dumps({
                     "status": "error",

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -802,6 +802,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._memory: Optional[Any] = None
         self._provider_sync_adapter: Optional[Any] = None
         self._provider_persona_adapter: Optional[Any] = None
+        # Coordinates only the shared-surface Beam and adapters that retain it.
+        # Construction is optimistic; publication validates this generation.
+        self._surface_adapter_lock = threading.RLock()
+        self._surface_generation = 0
         self._gateway_session_key = ""
         self._channel_id_explicit = False
         # Default scope for remember() calls when not explicitly specified.
@@ -918,6 +922,21 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         attr_name,
                         exc_info=True,
                     )
+
+    def _ensure_surface_adapter_lock(self):
+        """Return the surface lifecycle lock, including for __new__ tests."""
+        try:
+            return self._surface_adapter_lock
+        except AttributeError:
+            return self.__dict__.setdefault(
+                "_surface_adapter_lock", threading.RLock()
+            )
+
+    def _invalidate_surface_locked(self) -> None:
+        """Invalidate adapters and their Beam as one lifecycle transition."""
+        self._clear_provider_adapters()
+        self._surface_beam = None
+        self._surface_generation = getattr(self, "_surface_generation", 0) + 1
 
     def _audit_event(self, action: str, **kwargs) -> None:
         """Record an audit event. Never raises, never blocks."""
@@ -1353,7 +1372,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
         with self._ensure_beam_access_lock():
-            self._initialize_locked(session_id, **kwargs)
+            with self._ensure_surface_adapter_lock():
+                self._initialize_locked(session_id, **kwargs)
 
     def _initialize_locked(self, session_id: str, **kwargs) -> None:
         """Rebuild provider state while the Beam access lock is held."""
@@ -1365,7 +1385,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # _beam active, causing system_prompt_block() to report "Active"
         # and handle_tool_call() to silently write into the wrong session.
         # _init_error reset complements this for the failure-recovery case.
-        self._clear_provider_adapters()
+        self._invalidate_surface_locked()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -1379,7 +1399,6 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._memory = None
         self._audit = None
         self._beam = None
-        self._surface_beam = None
         self._init_error = None
         # A fresh initialize() supersedes any pending transient-failure retry;
         # the except path below re-stashes if THIS attempt also fails.
@@ -2149,13 +2168,32 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def _handle_sync_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
         try:
-            adapter = getattr(self, "_provider_sync_adapter", None)
-            if adapter is None:
-                from mnemosyne_hermes.sync_adapter import SyncAdapter
-                self._ensure_surface_beam()
-                adapter = SyncAdapter(self._surface_beam, {})
-                self._provider_sync_adapter = adapter
-            return adapter.handle_tool_call(tool_name, args)
+            from mnemosyne_hermes.sync_adapter import SyncAdapter
+
+            while True:
+                with self._ensure_surface_adapter_lock():
+                    adapter = getattr(self, "_provider_sync_adapter", None)
+                    if adapter is not None:
+                        return adapter.handle_tool_call(tool_name, args)
+                    self._ensure_surface_beam_locked()
+                    surface_beam = self._surface_beam
+                    generation = getattr(self, "_surface_generation", 0)
+
+                candidate = SyncAdapter(surface_beam, {})
+                with self._ensure_surface_adapter_lock():
+                    if (
+                        generation != getattr(self, "_surface_generation", 0)
+                        or self._surface_beam is not surface_beam
+                    ):
+                        candidate.shutdown()
+                        continue
+                    adapter = getattr(self, "_provider_sync_adapter", None)
+                    if adapter is None:
+                        adapter = candidate
+                        self._provider_sync_adapter = adapter
+                    else:
+                        candidate.shutdown()
+                    return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:
             return json.dumps({"status": "error", "error": f"Sync adapter unavailable: {exc}"})
 
@@ -2392,6 +2430,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return f"{label}: {content}"
 
     def _ensure_surface_beam(self) -> None:
+        with self._ensure_surface_adapter_lock():
+            self._ensure_surface_beam_locked()
+
+    def _ensure_surface_beam_locked(self) -> None:
         if self._surface_beam is not None:
             return
         BeamMemory = _get_beam_class()
@@ -3413,7 +3455,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # Releasing a non-owner (skip context or failed initialization) is a no-op;
         # the final owner clears the global backend.
         self._release_host_llm_backend_ownership()
-        self._clear_provider_adapters()
+        with self._ensure_surface_adapter_lock():
+            self._invalidate_surface_locked()
         if self._memory is not None:
             try:
                 self._memory.close()
@@ -3427,7 +3470,6 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Mnemosyne: could not close audit log", exc_info=True)
         self._audit = None
         self._beam = None
-        self._surface_beam = None
 
         # C13: decrement this instance's contribution to the module-level
         # active-provider count. ``_provider_active`` stays True if other
@@ -3552,19 +3594,41 @@ def _get_sync_handler(tool_name: str):
     """Return a handler fn that lazy-inits SyncAdapter on first use."""
     def _handler(args: dict) -> str:
         global _sync_adapter
-        if _sync_adapter is None:
-            try:
-                from mnemosyne_hermes.sync_adapter import SyncAdapter as SA
-                if _provider is None:
+        try:
+            from mnemosyne_hermes.sync_adapter import SyncAdapter as SA
+
+            while True:
+                provider = _provider
+                if provider is None:
                     raise RuntimeError("Mnemosyne provider is not initialized")
-                _provider._ensure_surface_beam()
-                _sync_adapter = SA(_provider._surface_beam)
-            except Exception:
-                return json.dumps({
-                    "status": "error",
-                    "error": "Sync adapter unavailable. Install mnemosyne-memory[sync].",
-                })
-        return _sync_adapter.handle_tool_call(tool_name, args)
+                with provider._ensure_surface_adapter_lock():
+                    if _provider is not provider:
+                        continue
+                    if _sync_adapter is not None:
+                        return _sync_adapter.handle_tool_call(tool_name, args)
+                    provider._ensure_surface_beam_locked()
+                    surface_beam = provider._surface_beam
+                    generation = getattr(provider, "_surface_generation", 0)
+
+                candidate = SA(surface_beam)
+                with provider._ensure_surface_adapter_lock():
+                    if (
+                        _provider is not provider
+                        or generation != getattr(provider, "_surface_generation", 0)
+                        or provider._surface_beam is not surface_beam
+                    ):
+                        candidate.shutdown()
+                        continue
+                    if _sync_adapter is None:
+                        _sync_adapter = candidate
+                    else:
+                        candidate.shutdown()
+                    return _sync_adapter.handle_tool_call(tool_name, args)
+        except Exception:
+            return json.dumps({
+                "status": "error",
+                "error": "Sync adapter unavailable. Install mnemosyne-memory[sync].",
+            })
     return _handler
 
 

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -890,21 +890,34 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             logger.debug("Audit log init skipped: %s", exc)
 
     def _clear_provider_adapters(self) -> None:
-        """Drop adapters that retain the Beam being replaced or closed."""
-        for attr_name in ("_provider_sync_adapter", "_provider_persona_adapter"):
-            adapter = getattr(self, attr_name, None)
-            if adapter is not None:
-                shutdown = getattr(adapter, "shutdown", None)
-                if callable(shutdown):
-                    try:
-                        shutdown()
-                    except Exception:
-                        logger.debug(
-                            "Mnemosyne: could not close provider adapter %s",
-                            attr_name,
-                            exc_info=True,
-                        )
-            setattr(self, attr_name, None)
+        """Drop adapters that retain a Beam being replaced or closed."""
+        global _sync_adapter
+
+        adapters = [
+            (attr_name, getattr(self, attr_name, None))
+            for attr_name in ("_provider_sync_adapter", "_provider_persona_adapter")
+        ]
+        self._provider_sync_adapter = None
+        self._provider_persona_adapter = None
+        if globals().get("_provider") is self:
+            adapters.append(("_sync_adapter", globals().get("_sync_adapter")))
+            _sync_adapter = None
+
+        seen: Set[int] = set()
+        for attr_name, adapter in adapters:
+            if adapter is None or id(adapter) in seen:
+                continue
+            seen.add(id(adapter))
+            shutdown = getattr(adapter, "shutdown", None)
+            if callable(shutdown):
+                try:
+                    shutdown()
+                except Exception:
+                    logger.debug(
+                        "Mnemosyne: could not close provider adapter %s",
+                        attr_name,
+                        exc_info=True,
+                    )
 
     def _audit_event(self, action: str, **kwargs) -> None:
         """Record an audit event. Never raises, never blocks."""
@@ -3414,6 +3427,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 logger.debug("Mnemosyne: could not close audit log", exc_info=True)
         self._audit = None
         self._beam = None
+        self._surface_beam = None
 
         # C13: decrement this instance's contribution to the module-level
         # active-provider count. ``_provider_active`` stays True if other

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -3589,6 +3589,7 @@ def register(ctx):
 
 # Lazy-init sync adapter for standalone plugin (v0.2.0)
 _sync_adapter: Optional[Any] = None
+_SYNC_ADAPTER_MAX_ATTEMPTS = 3
 
 def _get_sync_handler(tool_name: str):
     """Return a handler fn that lazy-inits SyncAdapter on first use."""
@@ -3597,7 +3598,7 @@ def _get_sync_handler(tool_name: str):
         try:
             from mnemosyne_hermes.sync_adapter import SyncAdapter as SA
 
-            while True:
+            for _attempt in range(_SYNC_ADAPTER_MAX_ATTEMPTS):
                 provider = _provider
                 if provider is None:
                     raise RuntimeError("Mnemosyne provider is not initialized")
@@ -3624,6 +3625,7 @@ def _get_sync_handler(tool_name: str):
                     else:
                         candidate.shutdown()
                     return _sync_adapter.handle_tool_call(tool_name, args)
+            raise RuntimeError("Sync adapter surface changed during every construction attempt")
         except Exception:
             return json.dumps({
                 "status": "error",

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -285,6 +285,13 @@ class SyncAdapter:
 
     # --- Push --------------------------------------------------------------
 
+    def _pull_cursor(self, remote: Optional[str] = None) -> str:
+        """Return the cursor persisted by SyncEngine for this pull remote."""
+        remote_url = (remote or self.remote).rstrip("/")
+        if not remote_url:
+            return ""
+        return str(self._engine._meta_get(f"last_pull_cursor_{remote_url}") or "")
+
     def _handle_push(self) -> str:
         if not self.remote:
             return json.dumps({
@@ -302,7 +309,7 @@ class SyncAdapter:
 
         push = result.get("push") or {}
         accepted = push.get("accepted", 0)
-        cursor = str(push.get("next_cursor") or "")
+        cursor = ""
         discovered = push.get("discovered") or {}
         if not accepted and not any(discovered.values()) and not push.get("batches"):
             return json.dumps({
@@ -337,7 +344,7 @@ class SyncAdapter:
             return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
         pull = result.get("pull") or {}
-        cursor = str(pull.get("next_cursor") or "")
+        cursor = self._pull_cursor(result.get("remote"))
         if (
             not pull.get("accepted")
             and not pull.get("events_fetched")
@@ -364,7 +371,7 @@ class SyncAdapter:
         if not engine:
             return json.dumps({"status": "error", "error": "No engine"})
 
-        cursor = engine._meta_get("last_sync_cursor") or ""
+        cursor = self._pull_cursor()
         device_id = getattr(engine, "device_id", "unknown")
 
         # Count local events

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -194,6 +194,7 @@ class SyncAdapter:
                     "sync requires the dedicated global shared surface; "
                     f"expected session {_SURFACE_SESSION_ID!r}"
                 )
+            # SQLite IS NOT is null-safe, so NULL scope/session values are invalid.
             existing_rows, invalid_rows = beam.conn.execute(
                 """SELECT COUNT(*), COALESCE(SUM(
                        CASE WHEN scope IS NOT 'global' OR session_id IS NOT ? THEN 1 ELSE 0 END

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -32,11 +32,13 @@ import os
 import threading
 import urllib.request
 import urllib.error
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_SURFACE_ID = "shared-surface-v1"
+_SURFACE_SESSION_ID = "hermes_shared_surface"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +187,26 @@ class SyncAdapter:
         try:
             from mnemosyne.core.sync import SyncEngine, SyncEncryption
 
+            beam = getattr(self._beam, "beam", self._beam)
+            session_id = getattr(beam, "session_id", None)
+            if session_id != _SURFACE_SESSION_ID:
+                raise ValueError(
+                    "sync requires the dedicated global shared surface; "
+                    f"expected session {_SURFACE_SESSION_ID!r}"
+                )
+            existing_rows, invalid_rows = beam.conn.execute(
+                """SELECT COUNT(*), COALESCE(SUM(
+                       CASE WHEN scope IS NOT 'global' OR session_id IS NOT ? THEN 1 ELSE 0 END
+                   ), 0)
+                   FROM working_memory""",
+                (_SURFACE_SESSION_ID,),
+            ).fetchone()
+            if invalid_rows:
+                raise ValueError(
+                    "sync requires a dedicated global shared surface; "
+                    "found private or foreign-session rows"
+                )
+
             encryption = None
             if self.encrypt_enabled and self.encryption_key:
                 encryption = SyncEncryption.from_config(key_source=self.encryption_key)
@@ -199,6 +221,10 @@ class SyncAdapter:
             self._engine = SyncEngine(
                 beam_instance=self._beam,
                 encryption=encryption,
+                surface_only=True,
+                surface_id=_SURFACE_ID,
+                initialize_surface=True,
+                claim_existing_surface=bool(existing_rows),
             )
             logger.info(
                 "SyncAdapter initialized: device=%s, remote=%s, encrypt=%s",
@@ -266,34 +292,30 @@ class SyncAdapter:
                 "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
             })
 
-        # Last cursor from sync_meta
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        changes = self._engine.pull_changes(since_cursor=cursor or None, limit=500)
+        result = self._engine.sync_with(
+            self.remote,
+            mode="push",
+            api_key=self.auth_token or None,
+        )
+        if result.get("errors"):
+            return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
-        events = changes.get("events", [])
-        if not events:
+        push = result.get("push") or {}
+        accepted = push.get("accepted", 0)
+        cursor = str(push.get("next_cursor") or "")
+        discovered = push.get("discovered") or {}
+        if not accepted and not any(discovered.values()) and not push.get("batches"):
             return json.dumps({
                 "status": "ok",
                 "pushed": 0,
                 "message": "No local changes to push.",
             })
 
-        # Push to remote
-        result = self._http_post("/sync/push", {"events": events})
-        if result.get("status") != "ok":
-            return json.dumps(result)
-
-        accepted = result.get("accepted", 0)
-        cursor = result.get("next_cursor") or changes.get("next_cursor") or ""
-
-        if cursor:
-            self._engine._meta_set("last_sync_cursor", cursor)
-
         return json.dumps({
             "status": "ok",
             "pushed": accepted,
-            "duplicates": result.get("duplicates", 0),
-            "conflicts": result.get("conflicts", 0),
+            "duplicates": push.get("duplicates", 0),
+            "conflicts": push.get("conflicts", 0),
             "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
         })
 
@@ -306,33 +328,32 @@ class SyncAdapter:
                 "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
             })
 
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        result = self._http_post("/sync/pull", {"since_token": cursor or None})
+        result = self._engine.sync_with(
+            self.remote,
+            mode="pull",
+            api_key=self.auth_token or None,
+        )
+        if result.get("errors"):
+            return json.dumps({"status": "error", "error": "; ".join(result["errors"])})
 
-        if result.get("status") != "ok":
-            return json.dumps(result)
-
-        incoming = result.get("events", [])
-        if not incoming:
+        pull = result.get("pull") or {}
+        cursor = str(pull.get("next_cursor") or "")
+        if (
+            not pull.get("accepted")
+            and not pull.get("events_fetched")
+            and not pull.get("batches")
+        ):
             return json.dumps({
                 "status": "ok",
                 "pulled": 0,
                 "message": "No remote changes to pull.",
             })
 
-        # Apply locally
-        push_result = self._engine.push_changes(incoming)
-        accepted = push_result.get("accepted", 0)
-        cursor = result.get("next_cursor") or ""
-
-        if cursor:
-            self._engine._meta_set("last_sync_cursor", cursor)
-
         return json.dumps({
             "status": "ok",
-            "pulled": accepted,
-            "duplicates": push_result.get("duplicates", 0),
-            "conflicts": push_result.get("conflicts", 0),
+            "pulled": pull.get("accepted", 0),
+            "duplicates": pull.get("duplicates", 0),
+            "conflicts": pull.get("conflicts", 0),
             "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
         })
 

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -1126,9 +1126,10 @@ def test_sync_adapter_schema_and_lifecycle_surface_match(sync_modules):
 
 
 class _FakeSyncEngine:
-    def __init__(self, beam_instance, encryption=None):
+    def __init__(self, beam_instance, encryption=None, **kwargs):
         self.beam_instance = beam_instance
         self.encryption = encryption
+        self.kwargs = kwargs
         self.device_id = "fake-device"
 
 
@@ -1147,6 +1148,19 @@ class _UnexpectedBeam:
         self.kwargs = kwargs
 
 
+class _FakeSurfaceConnection:
+    def execute(self, _sql, _params=()):
+        return self
+
+    def fetchone(self):
+        return (0, 0)
+
+
+class _FakeSurfaceBeam:
+    session_id = "hermes_shared_surface"
+    conn = _FakeSurfaceConnection()
+
+
 def _install_fake_sync_modules(monkeypatch):
     import types
 
@@ -1162,11 +1176,87 @@ def _install_fake_sync_modules(monkeypatch):
 def test_sync_adapter_uses_provider_beam_for_both_surfaces(monkeypatch, sync_modules):
     _install_fake_sync_modules(monkeypatch)
 
-    provider_beam = object()
+    provider_beam = _FakeSurfaceBeam()
     for module in sync_modules.values():
         adapter = module.SyncAdapter(provider_beam, {})
         assert adapter.is_ready is True
         assert adapter._engine.beam_instance is provider_beam
+        assert adapter._engine.kwargs == {
+            "surface_only": True,
+            "surface_id": "shared-surface-v1",
+            "initialize_surface": True,
+            "claim_existing_surface": False,
+        }
+
+
+def test_provider_sync_tools_bind_to_shared_surface(
+    monkeypatch, provider_modules
+):
+    for name, module in provider_modules.items():
+        private_beam = object()
+        surface_beam = object()
+        observed = []
+
+        class _Adapter:
+            def __init__(self, beam, _config):
+                observed.append(beam)
+
+            def handle_tool_call(self, tool_name, args):
+                return json.dumps({"tool": tool_name, "args": args})
+
+        fake_sync_module = types.ModuleType(f"{name}.sync_adapter")
+        setattr(fake_sync_module, "SyncAdapter", _Adapter)
+        monkeypatch.setitem(sys.modules, f"{name}.sync_adapter", fake_sync_module)
+        provider = module.MnemosyneMemoryProvider.__new__(
+            module.MnemosyneMemoryProvider
+        )
+        provider._beam = private_beam
+        provider._surface_beam = surface_beam
+        if name == "hermes_memory_provider":
+            provider._sync_adapter = None
+        else:
+            provider._provider_sync_adapter = None
+
+        result = json.loads(
+            provider._handle_sync_tool("mnemosyne_sync_status", {})
+        )
+
+        assert result["tool"] == "mnemosyne_sync_status"
+        assert observed == [surface_beam]
+
+
+def test_standalone_sync_handler_binds_provider_shared_surface(
+    monkeypatch, provider_modules
+):
+    module = provider_modules["mnemosyne_hermes"]
+    surface_beam = object()
+    observed = []
+
+    class _Provider:
+        _surface_beam = surface_beam
+
+        def _ensure_surface_beam(self):
+            return None
+
+    class _Adapter:
+        def __init__(self, beam):
+            observed.append(beam)
+
+        def handle_tool_call(self, tool_name, args):
+            return json.dumps({"tool": tool_name, "args": args})
+
+    fake_sync_module = types.ModuleType("mnemosyne_hermes.sync_adapter")
+    setattr(fake_sync_module, "SyncAdapter", _Adapter)
+    monkeypatch.setitem(
+        sys.modules, "mnemosyne_hermes.sync_adapter", fake_sync_module
+    )
+    monkeypatch.setattr(module, "_provider", _Provider())
+    monkeypatch.setattr(module, "_sync_adapter", None)
+
+    result = json.loads(module._get_sync_handler("mnemosyne_sync_status")({}))
+
+    assert result["tool"] == "mnemosyne_sync_status"
+    assert observed == [surface_beam]
 
 
 def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
@@ -1177,7 +1267,9 @@ def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
 
     observed = {}
     for name, module in sync_modules.items():
-        adapter = module.SyncAdapter(object(), {"encrypt": True, "key": "encoded-key"})
+        adapter = module.SyncAdapter(
+            _FakeSurfaceBeam(), {"encrypt": True, "key": "encoded-key"}
+        )
         observed[name] = {
             "remote": adapter.remote,
             "encryption_key_source": adapter._engine.encryption.key_source,
@@ -1225,6 +1317,19 @@ class _ToolEngine:
         self.pushed_events = events
         return {"accepted": 2, "duplicates": 1, "conflicts": 1}
 
+    def sync_with(self, _remote, mode="bidirectional", api_key=None):
+        phase = {
+            "accepted": 2,
+            "duplicates": 1,
+            "conflicts": 1,
+            "next_cursor": self.local_next_cursor,
+        }
+        return {
+            "push": phase if mode == "push" else None,
+            "pull": phase if mode == "pull" else None,
+            "errors": [],
+        }
+
     def execute(self, _sql):
         return self
 
@@ -1240,6 +1345,7 @@ def _adapter_with_tool_engine(
 ):
     adapter = module.SyncAdapter.__new__(module.SyncAdapter)
     adapter._engine = _ToolEngine(local_next_cursor=local_next_cursor)
+    adapter._engine.local_next_cursor = next_cursor
     adapter._error = None
     adapter.remote = "https://sync.example"
     adapter.encrypt_enabled = False

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -1475,6 +1475,78 @@ def test_standalone_sync_construction_race_retries_current_surface(
     assert module._sync_adapter is None
 
 
+@pytest.mark.parametrize("invalidation", ["generation", "provider"])
+def test_standalone_sync_construction_retry_exhaustion_is_fail_soft(
+    monkeypatch, provider_modules, invalidation
+):
+    module = provider_modules["mnemosyne_hermes"]
+    max_attempts = module._SYNC_ADAPTER_MAX_ATTEMPTS
+    construction_started = [threading.Event() for _ in range(max_attempts)]
+    release_construction = [threading.Event() for _ in range(max_attempts)]
+    constructed = []
+    shutdown = []
+    result = []
+
+    class _Provider:
+        def __init__(self, surface):
+            self._surface_beam = surface
+            self._surface_generation = 0
+            self._surface_adapter_lock = threading.RLock()
+
+        def _ensure_surface_adapter_lock(self):
+            return self._surface_adapter_lock
+
+        def _ensure_surface_beam_locked(self):
+            return None
+
+    class _Adapter:
+        def __init__(self, beam):
+            self.beam = beam
+            attempt = len(constructed)
+            constructed.append(beam)
+            if attempt >= max_attempts:
+                raise AssertionError("retry limit was exceeded")
+            construction_started[attempt].set()
+            assert release_construction[attempt].wait(5)
+
+        def handle_tool_call(self, _tool_name, _args):
+            raise AssertionError("an invalidated adapter must not handle the call")
+
+        def shutdown(self):
+            shutdown.append(self.beam)
+
+    fake_sync_module = types.ModuleType("mnemosyne_hermes.sync_adapter")
+    setattr(fake_sync_module, "SyncAdapter", _Adapter)
+    monkeypatch.setitem(sys.modules, "mnemosyne_hermes.sync_adapter", fake_sync_module)
+    provider = _Provider(object())
+    monkeypatch.setattr(module, "_provider", provider)
+    monkeypatch.setattr(module, "_sync_adapter", None)
+    handler = module._get_sync_handler("mnemosyne_sync_status")
+
+    worker = threading.Thread(target=lambda: result.append(handler({})))
+    worker.start()
+    for attempt in range(max_attempts):
+        assert construction_started[attempt].wait(5)
+        current_provider = module._provider
+        with current_provider._ensure_surface_adapter_lock():
+            if invalidation == "generation":
+                current_provider._surface_generation += 1
+                current_provider._surface_beam = object()
+            else:
+                module._provider = _Provider(object())
+        release_construction[attempt].set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert json.loads(result[0]) == {
+        "status": "error",
+        "error": "Sync adapter unavailable. Install mnemosyne-memory[sync].",
+    }
+    assert len(constructed) == max_attempts
+    assert shutdown == constructed
+    assert module._sync_adapter is None
+
+
 def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
     _install_fake_sync_modules(monkeypatch)
     monkeypatch.delenv("MNEMOSYNE_SYNC_REMOTE", raising=False)

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -1234,8 +1234,13 @@ def test_standalone_sync_handler_binds_provider_shared_surface(
 
     class _Provider:
         _surface_beam = surface_beam
+        _surface_generation = 0
+        _surface_adapter_lock = threading.RLock()
 
-        def _ensure_surface_beam(self):
+        def _ensure_surface_adapter_lock(self):
+            return self._surface_adapter_lock
+
+        def _ensure_surface_beam_locked(self):
             return None
 
     class _Adapter:
@@ -1345,6 +1350,129 @@ def test_reinitialize_rebinds_standalone_sync_handler_to_new_surface(
     assert shutdown == [surface_a, surface_b]
     assert module._sync_adapter is None
     assert provider._surface_beam is None
+
+
+def test_provider_sync_construction_race_retries_current_surface(
+    monkeypatch, provider_modules
+):
+    for name, module in provider_modules.items():
+        surface_a = object()
+        surface_b = object()
+        construction_started = threading.Event()
+        release_construction = threading.Event()
+        constructed = []
+        handled = []
+        shutdown = []
+        result = []
+
+        class _Adapter:
+            def __init__(self, beam, _config):
+                self.beam = beam
+                constructed.append(beam)
+                if beam is surface_a:
+                    construction_started.set()
+                    assert release_construction.wait(5)
+
+            def handle_tool_call(self, _tool_name, _args):
+                handled.append(self.beam)
+                return "ok"
+
+            def shutdown(self):
+                shutdown.append(self.beam)
+
+        fake_sync_module = types.ModuleType(f"{name}.sync_adapter")
+        setattr(fake_sync_module, "SyncAdapter", _Adapter)
+        monkeypatch.setitem(sys.modules, f"{name}.sync_adapter", fake_sync_module)
+        provider = module.MnemosyneMemoryProvider()
+        provider._surface_beam = surface_a
+
+        worker = threading.Thread(
+            target=lambda: result.append(
+                provider._handle_sync_tool("mnemosyne_sync_status", {})
+            )
+        )
+        worker.start()
+        assert construction_started.wait(5)
+
+        provider.initialize("replacement", agent_context="subagent")
+        with provider._ensure_surface_adapter_lock():
+            provider._surface_beam = surface_b
+        release_construction.set()
+        worker.join(5)
+
+        assert not worker.is_alive()
+        assert result == ["ok"]
+        assert constructed == [surface_a, surface_b]
+        assert handled == [surface_b]
+        assert shutdown == [surface_a]
+        cache_name = (
+            "_sync_adapter"
+            if name == "hermes_memory_provider"
+            else "_provider_sync_adapter"
+        )
+        assert getattr(provider, cache_name).beam is surface_b
+
+        provider.shutdown()
+        assert shutdown == [surface_a, surface_b]
+
+
+def test_standalone_sync_construction_race_retries_current_surface(
+    monkeypatch, provider_modules
+):
+    module = provider_modules["mnemosyne_hermes"]
+    surface_a = object()
+    surface_b = object()
+    construction_started = threading.Event()
+    release_construction = threading.Event()
+    constructed = []
+    handled = []
+    shutdown = []
+    result = []
+
+    class _Adapter:
+        def __init__(self, beam):
+            self.beam = beam
+            constructed.append(beam)
+            if beam is surface_a:
+                construction_started.set()
+                assert release_construction.wait(5)
+
+        def handle_tool_call(self, _tool_name, _args):
+            handled.append(self.beam)
+            return "ok"
+
+        def shutdown(self):
+            shutdown.append(self.beam)
+
+    fake_sync_module = types.ModuleType("mnemosyne_hermes.sync_adapter")
+    setattr(fake_sync_module, "SyncAdapter", _Adapter)
+    monkeypatch.setitem(sys.modules, "mnemosyne_hermes.sync_adapter", fake_sync_module)
+    provider = module.MnemosyneMemoryProvider()
+    monkeypatch.setattr(module, "_provider", provider)
+    monkeypatch.setattr(module, "_sync_adapter", None)
+    provider._surface_beam = surface_a
+    handler = module._get_sync_handler("mnemosyne_sync_status")
+
+    worker = threading.Thread(target=lambda: result.append(handler({})))
+    worker.start()
+    assert construction_started.wait(5)
+
+    provider.initialize("replacement", agent_context="subagent")
+    with provider._ensure_surface_adapter_lock():
+        provider._surface_beam = surface_b
+    release_construction.set()
+    worker.join(5)
+
+    assert not worker.is_alive()
+    assert result == ["ok"]
+    assert constructed == [surface_a, surface_b]
+    assert handled == [surface_b]
+    assert shutdown == [surface_a]
+    assert module._sync_adapter.beam is surface_b
+
+    provider.shutdown()
+    assert shutdown == [surface_a, surface_b]
+    assert module._sync_adapter is None
 
 
 def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -1259,6 +1259,94 @@ def test_standalone_sync_handler_binds_provider_shared_surface(
     assert observed == [surface_beam]
 
 
+def test_reinitialize_rebinds_provider_sync_adapter_to_new_surface(
+    monkeypatch, provider_modules
+):
+    for name, module in provider_modules.items():
+        surface_a = object()
+        surface_b = object()
+        constructed = []
+        handled = []
+        shutdown = []
+
+        class _Adapter:
+            def __init__(self, beam, _config):
+                self.beam = beam
+                constructed.append(beam)
+
+            def handle_tool_call(self, _tool_name, _args):
+                handled.append(self.beam)
+                return "ok"
+
+            def shutdown(self):
+                shutdown.append(self.beam)
+
+        fake_sync_module = types.ModuleType(f"{name}.sync_adapter")
+        setattr(fake_sync_module, "SyncAdapter", _Adapter)
+        monkeypatch.setitem(sys.modules, f"{name}.sync_adapter", fake_sync_module)
+        provider = module.MnemosyneMemoryProvider()
+        provider._surface_beam = surface_a
+
+        assert provider._handle_sync_tool("mnemosyne_sync_status", {}) == "ok"
+        provider.initialize("replacement", agent_context="subagent")
+        provider._surface_beam = surface_b
+        assert provider._handle_sync_tool("mnemosyne_sync_status", {}) == "ok"
+
+        assert constructed == [surface_a, surface_b]
+        assert handled == [surface_a, surface_b]
+        assert shutdown == [surface_a]
+
+        provider.shutdown()
+        assert shutdown == [surface_a, surface_b]
+        assert provider._surface_beam is None
+
+
+def test_reinitialize_rebinds_standalone_sync_handler_to_new_surface(
+    monkeypatch, provider_modules
+):
+    module = provider_modules["mnemosyne_hermes"]
+    surface_a = object()
+    surface_b = object()
+    constructed = []
+    handled = []
+    shutdown = []
+
+    class _Adapter:
+        def __init__(self, beam):
+            self.beam = beam
+            constructed.append(beam)
+
+        def handle_tool_call(self, _tool_name, _args):
+            handled.append(self.beam)
+            return "ok"
+
+        def shutdown(self):
+            shutdown.append(self.beam)
+
+    fake_sync_module = types.ModuleType("mnemosyne_hermes.sync_adapter")
+    setattr(fake_sync_module, "SyncAdapter", _Adapter)
+    monkeypatch.setitem(sys.modules, "mnemosyne_hermes.sync_adapter", fake_sync_module)
+    provider = module.MnemosyneMemoryProvider()
+    monkeypatch.setattr(module, "_provider", provider)
+    monkeypatch.setattr(module, "_sync_adapter", None)
+    provider._surface_beam = surface_a
+    handler = module._get_sync_handler("mnemosyne_sync_status")
+
+    assert handler({}) == "ok"
+    provider.initialize("replacement", agent_context="subagent")
+    provider._surface_beam = surface_b
+    assert handler({}) == "ok"
+
+    assert constructed == [surface_a, surface_b]
+    assert handled == [surface_a, surface_b]
+    assert shutdown == [surface_a]
+
+    provider.shutdown()
+    assert shutdown == [surface_a, surface_b]
+    assert module._sync_adapter is None
+    assert provider._surface_beam is None
+
+
 def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
     _install_fake_sync_modules(monkeypatch)
     monkeypatch.delenv("MNEMOSYNE_SYNC_REMOTE", raising=False)
@@ -1299,10 +1387,10 @@ def test_sync_adapter_key_source_file_preserves_path_case(tmp_path, sync_modules
 class _ToolEngine:
     device_id = "device-1"
 
-    def __init__(self, *, local_next_cursor: str | None = "local-cursor"):
-        self.meta = {"last_sync_cursor": "cursor-previous"}
+    def __init__(self, *, pull_cursor: str | None = "local-cursor"):
+        self.meta = {}
         self.conn = self
-        self.local_next_cursor = local_next_cursor
+        self.pull_cursor = pull_cursor
 
     def _meta_get(self, key):
         return self.meta.get(key)
@@ -1310,21 +1398,20 @@ class _ToolEngine:
     def _meta_set(self, key, value):
         self.meta[key] = value
 
-    def pull_changes(self, since_cursor=None, limit=500):
-        return {"events": [{"id": "e1"}], "next_cursor": self.local_next_cursor}
-
-    def push_changes(self, events):
-        self.pushed_events = events
-        return {"accepted": 2, "duplicates": 1, "conflicts": 1}
-
-    def sync_with(self, _remote, mode="bidirectional", api_key=None):
+    def sync_with(self, remote, mode="bidirectional", api_key=None):
         phase = {
             "accepted": 2,
             "duplicates": 1,
             "conflicts": 1,
-            "next_cursor": self.local_next_cursor,
+            "events_fetched": 2,
+            "batches": 1,
         }
+        if mode == "pull" and self.pull_cursor is not None:
+            self._meta_set(
+                f"last_pull_cursor_{remote.rstrip('/')}", self.pull_cursor
+            )
         return {
+            "remote": remote.rstrip("/"),
             "push": phase if mode == "push" else None,
             "pull": phase if mode == "pull" else None,
             "errors": [],
@@ -1340,30 +1427,16 @@ class _ToolEngine:
 def _adapter_with_tool_engine(
     module,
     *,
-    next_cursor: str | None = "remote-cursor",
-    local_next_cursor: str | None = "local-cursor",
+    pull_cursor: str | None = "remote-cursor",
 ):
     adapter = module.SyncAdapter.__new__(module.SyncAdapter)
-    adapter._engine = _ToolEngine(local_next_cursor=local_next_cursor)
-    adapter._engine.local_next_cursor = next_cursor
+    adapter._engine = _ToolEngine(pull_cursor=pull_cursor)
     adapter._error = None
     adapter.remote = "https://sync.example"
     adapter.encrypt_enabled = False
     adapter.mode = "bidirectional"
     adapter.auth_token = ""
 
-    def fake_post(_path, _payload):
-        return {
-            "status": "ok",
-            "accepted": 2,
-            "duplicates": 1,
-            "conflicts": 1,
-            "events": [{"id": "remote-1"}, {"id": "remote-2"}],
-            "next_cursor": next_cursor,
-        }
-
-    adapter._http_post = fake_post
-    adapter._post = fake_post
     return adapter
 
 
@@ -1384,7 +1457,7 @@ def test_sync_adapter_tool_results_match(sync_modules):
         "pushed": 2,
         "duplicates": 1,
         "conflicts": 1,
-        "next_cursor": "remote-cursor",
+        "next_cursor": "",
     }
     assert observed["hermes_memory_provider"]["pull"] == {
         "status": "ok",
@@ -1398,7 +1471,7 @@ def test_sync_adapter_tool_results_match(sync_modules):
 def test_sync_adapter_push_tolerates_null_next_cursor(sync_modules):
     observed = {}
     for name, module in sync_modules.items():
-        adapter = _adapter_with_tool_engine(module, next_cursor=None, local_next_cursor=None)
+        adapter = _adapter_with_tool_engine(module, pull_cursor=None)
         observed[name] = json.loads(adapter.handle_tool_call("mnemosyne_sync_push", {}))
 
     assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
@@ -1415,7 +1488,7 @@ def test_sync_adapter_push_tolerates_null_next_cursor(sync_modules):
 def test_sync_adapter_pull_tolerates_null_next_cursor(sync_modules):
     observed = {}
     for name, module in sync_modules.items():
-        adapter = _adapter_with_tool_engine(module, next_cursor=None)
+        adapter = _adapter_with_tool_engine(module, pull_cursor=None)
         observed[name] = json.loads(adapter.handle_tool_call("mnemosyne_sync_pull", {}))
 
     assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]

--- a/tests/test_hermes_sync_adapter.py
+++ b/tests/test_hermes_sync_adapter.py
@@ -211,3 +211,29 @@ def test_surface_startup_rejects_non_shared_session_without_mutation(
     assert adapter.is_ready is False
     assert "expected session" in adapter._error
     assert _database_snapshot(beam.conn) == before
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["mnemosyne_sync_push", "mnemosyne_sync_pull"]
+)
+def test_sync_tool_reports_joined_engine_errors(sync_module, tool_name):
+    class _ErrorEngine:
+        def sync_with(self, *_args, **_kwargs):
+            return {
+                "push": None,
+                "pull": None,
+                "errors": ["first sync failure", "second sync failure"],
+            }
+
+    adapter = sync_module.SyncAdapter.__new__(sync_module.SyncAdapter)
+    adapter._engine = _ErrorEngine()
+    adapter._error = None
+    adapter.remote = "https://sync.example"
+    adapter.auth_token = ""
+
+    result = json.loads(adapter.handle_tool_call(tool_name, {}))
+
+    assert result == {
+        "status": "error",
+        "error": "first sync failure; second sync failure",
+    }

--- a/tests/test_hermes_sync_adapter.py
+++ b/tests/test_hermes_sync_adapter.py
@@ -113,6 +113,65 @@ def test_push_tool_discovers_shared_global_memory_with_surface_id(
     assert json.loads(payload["metadata_json"]) == {"safe": "kept"}
 
 
+def test_pull_tool_and_status_report_real_persisted_remote_cursor(
+    tmp_path, monkeypatch, sync_module
+):
+    source_beam = BeamMemory(
+        session_id=SHARED_SESSION_ID,
+        db_path=tmp_path / "source.db",
+    )
+    source_adapter = sync_module.SyncAdapter(
+        source_beam,
+        {"remote": "https://source.example"},
+    )
+    source_adapter._engine.log_event(
+        "remote-memory",
+        "CREATE",
+        {
+            "content": "remote shared memory",
+            "source": "sync-test",
+            "scope": "global",
+            "session_id": SHARED_SESSION_ID,
+        },
+    )
+    [remote_event] = source_adapter._engine.pull_changes()["events"]
+    remote_cursor = "remote-cursor-after-page"
+
+    def fake_urlopen(_request, **_kwargs):
+        return _Response(
+            {
+                "events": [remote_event],
+                "next_cursor": remote_cursor,
+                "has_more": False,
+            }
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    receiver_beam = BeamMemory(
+        session_id=SHARED_SESSION_ID,
+        db_path=tmp_path / "receiver.db",
+    )
+    adapter = sync_module.SyncAdapter(
+        receiver_beam,
+        {"remote": "https://sync.example"},
+    )
+
+    pull_result = json.loads(adapter.handle_tool_call("mnemosyne_sync_pull", {}))
+    status_result = json.loads(adapter.handle_tool_call("mnemosyne_sync_status", {}))
+
+    assert pull_result == {
+        "status": "ok",
+        "pulled": 1,
+        "duplicates": 0,
+        "conflicts": 0,
+        "next_cursor": remote_cursor,
+    }
+    assert status_result["last_cursor"] == remote_cursor
+    assert adapter._engine._meta_get(
+        "last_pull_cursor_https://sync.example"
+    ) == remote_cursor
+
+
 @pytest.mark.parametrize(
     ("row_session", "scope"),
     (

--- a/tests/test_hermes_sync_adapter.py
+++ b/tests/test_hermes_sync_adapter.py
@@ -1,0 +1,154 @@
+"""Regression tests for the Hermes shared-surface sync adapter."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_SRC = PROJECT_ROOT / "integrations" / "hermes" / "src"
+SHARED_SESSION_ID = "hermes_shared_surface"
+SURFACE_ID = "shared-surface-v1"
+
+
+def _import_sync_module(package: str, import_root: Path):
+    for name in list(sys.modules):
+        if name == package or name.startswith(f"{package}."):
+            del sys.modules[name]
+    sys.path.insert(0, str(import_root))
+    try:
+        return importlib.import_module(f"{package}.sync_adapter")
+    finally:
+        sys.path.remove(str(import_root))
+
+
+@pytest.fixture(params=(
+    ("hermes_memory_provider", PROJECT_ROOT),
+    ("mnemosyne_hermes", INTEGRATION_SRC),
+))
+def sync_module(request):
+    package, import_root = request.param
+    return _import_sync_module(package, import_root)
+
+
+class _Response:
+    headers: dict[str, str] = {}
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _size: int = -1) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _database_snapshot(conn: sqlite3.Connection) -> tuple[list[tuple], list[tuple]]:
+    schema = conn.execute(
+        "SELECT type, name, sql FROM sqlite_master ORDER BY type, name"
+    ).fetchall()
+    rows = conn.execute("SELECT * FROM working_memory ORDER BY id").fetchall()
+    return [tuple(row) for row in schema], [tuple(row) for row in rows]
+
+
+def test_push_tool_discovers_shared_global_memory_with_surface_id(
+    tmp_path, monkeypatch, sync_module
+):
+    beam = BeamMemory(
+        session_id=SHARED_SESSION_ID,
+        db_path=tmp_path / "shared.db",
+    )
+    memory_id = beam.remember(
+        "shared sync probe",
+        source="surface_manual",
+        importance=0.8,
+        scope="global",
+        metadata={"source_profile_session": "private-session", "safe": "kept"},
+    )
+    requests: list[dict] = []
+
+    def fake_urlopen(request, **_kwargs):
+        body = json.loads(request.data.decode("utf-8"))
+        requests.append(body)
+        event_ids = [event["event_id"] for event in body["events"]]
+        return _Response(
+            {
+                "accepted": len(event_ids),
+                "duplicates": 0,
+                "conflicts": 0,
+                "errors": 0,
+                "acknowledged_event_ids": event_ids,
+            }
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    adapter = sync_module.SyncAdapter(
+        beam,
+        {"remote": "https://sync.example", "token": "relay-token"},
+    )
+
+    result = json.loads(adapter.handle_tool_call("mnemosyne_sync_push", {}))
+
+    assert result["status"] == "ok"
+    assert result["pushed"] == 1
+    assert len(requests) == 1
+    [event] = requests[0]["events"]
+    assert event["memory_id"] == memory_id
+    assert event["surface_id"] == SURFACE_ID
+    payload = json.loads(event["payload"])
+    assert payload["content"] == "shared sync probe"
+    assert "session_id" not in payload
+    assert json.loads(payload["metadata_json"]) == {"safe": "kept"}
+
+
+@pytest.mark.parametrize(
+    ("row_session", "scope"),
+    (
+        (SHARED_SESSION_ID, "session"),
+        ("foreign-session", "global"),
+    ),
+)
+def test_surface_startup_rejects_mixed_db_without_mutation(
+    tmp_path, sync_module, row_session, scope
+):
+    db_path = tmp_path / f"mixed-{row_session}-{scope}.db"
+    writer = BeamMemory(session_id=row_session, db_path=db_path)
+    writer.remember("must remain private", source="test", scope=scope)
+    shared_beam = BeamMemory(session_id=SHARED_SESSION_ID, db_path=db_path)
+    before = _database_snapshot(shared_beam.conn)
+
+    adapter = sync_module.SyncAdapter(
+        shared_beam,
+        {"remote": "https://sync.example"},
+    )
+
+    assert adapter.is_ready is False
+    result = json.loads(adapter.handle_tool_call("mnemosyne_sync_push", {}))
+    assert result["status"] == "error"
+    assert "dedicated global shared surface" in result["error"]
+    assert _database_snapshot(shared_beam.conn) == before
+
+
+def test_surface_startup_rejects_non_shared_session_without_mutation(
+    tmp_path, sync_module
+):
+    beam = BeamMemory(session_id="private-session", db_path=tmp_path / "private.db")
+    before = _database_snapshot(beam.conn)
+
+    adapter = sync_module.SyncAdapter(beam, {"remote": "https://sync.example"})
+
+    assert adapter.is_ready is False
+    assert "expected session" in adapter._error
+    assert _database_snapshot(beam.conn) == before

--- a/tests/test_mnemosyne_hermes_session_switch.py
+++ b/tests/test_mnemosyne_hermes_session_switch.py
@@ -1370,6 +1370,7 @@ def test_auto_sleep_eligibility_and_snapshot_share_switch_lock(
 
 
 def test_reinitialize_rebuilds_beam_bound_tool_adapters(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from mnemosyne_hermes import persona_adapter as persona_adapter_module
@@ -1419,6 +1420,7 @@ def test_reinitialize_rebuilds_beam_bound_tool_adapters(
     )
 
     provider, _ = _provider_with_recording_beam()
+    provider._shared_surface_path = tmp_path / "shared.db"
     provider.has_tool = lambda _name: True
     try:
         assert (

--- a/tests/test_mnemosyne_hermes_session_switch.py
+++ b/tests/test_mnemosyne_hermes_session_switch.py
@@ -1423,7 +1423,7 @@ def test_reinitialize_rebuilds_beam_bound_tool_adapters(
     try:
         assert (
             provider.handle_tool_call("mnemosyne_sync_status", {})
-            == "hermes_SESS-A"
+            == "hermes_shared_surface"
         )
         assert (
             provider.handle_tool_call("mnemosyne_persona_list", {})
@@ -1434,21 +1434,21 @@ def test_reinitialize_rebuilds_beam_bound_tool_adapters(
 
         assert (
             provider.handle_tool_call("mnemosyne_sync_status", {})
-            == "hermes_SESS-B"
+            == "hermes_shared_surface"
         )
         assert (
             provider.handle_tool_call("mnemosyne_persona_list", {})
             == "hermes_SESS-B"
         )
-        assert sync_constructed == ["hermes_SESS-A", "hermes_SESS-B"]
+        assert sync_constructed == ["hermes_shared_surface", "hermes_shared_surface"]
         assert persona_constructed == ["hermes_SESS-A", "hermes_SESS-B"]
-        assert sync_handled == ["hermes_SESS-A", "hermes_SESS-B"]
+        assert sync_handled == ["hermes_shared_surface", "hermes_shared_surface"]
         assert persona_handled == ["hermes_SESS-A", "hermes_SESS-B"]
-        assert sync_shutdown == ["hermes_SESS-A"]
+        assert sync_shutdown == ["hermes_shared_surface"]
     finally:
         provider.shutdown()
 
-    assert sync_shutdown == ["hermes_SESS-A", "hermes_SESS-B"]
+    assert sync_shutdown == ["hermes_shared_surface", "hermes_shared_surface"]
     assert provider._provider_sync_adapter is None
     assert provider._provider_persona_adapter is None
 


### PR DESCRIPTION
## Summary
Fixes #927.

- route Hermes sync tools through the dedicated `hermes_shared_surface` Beam and a `surface_only` `SyncEngine`
- use `SyncEngine.sync_with()` so push discovers local mutations and follows the authenticated relay path
- report the real per-remote pull cursor, and invalidate/rebind cached adapters safely across surface reinitialization
- add deterministic regressions for private/foreign-row rejection, push/pull isolation, cursor reporting, sequential rebinding, and the lazy-construction versus reinitialization race

## Contract
Only the dedicated global shared surface may synchronize. Private or foreign-session rows fail closed before schema or row mutation; they are not claimed or exported.

## Why this path
The adapter already has a maintained shared-surface Beam. Binding the sync engine to it fixes both reported defects without changing the sync protocol or migrating existing databases.

## Non-goals
No sync-server/protocol change, no automatic migration of mixed databases, no new public configuration model, and no tool-schema change.

## Verification
- `uv run --extra sync pytest -q tests/test_hermes_sync_adapter.py tests/test_hermes_provider_parity.py tests/test_tool_surface_parity.py tests/test_sync_correctness.py tests/test_sync_security.py` → 159 passed, 1 skipped
- Standalone reinitialization and sync-surface selectors passed; one unrelated session-switch test is reproducibly failing on the exact base commit.
- Independent final security/concurrency review: approved, including 20 repeated deterministic race-test runs.
- `py_compile` and `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Routes Hermes synchronization through the dedicated `hermes_shared_surface` Beam.
- Uses `SyncEngine.sync_with()` with `surface_only=True` for authenticated push and pull.
- Discovers local mutations before push.
- Reports the real per-remote pull cursor.
- Rejects private and foreign-session rows before schema or row mutation.
- Rebinds cached adapters safely during surface reinitialization and shutdown.
- Adds bounded retries for the standalone sync adapter.

## Architecture impact

- **Sync layer:** Corrects Hermes push and pull behavior without changing the sync protocol, database schema, or public configuration.
- **Privacy:** Only the global shared surface can synchronize. Private and foreign-session data is not claimed or exported.
- **Local-first design:** Local writes remain authoritative. Explicit sync discovers local mutations and uses the existing authenticated relay path. The change does not erode local-first guarantees.
- **Hermes integration:** Provider-managed and standalone sync handlers bind to the active shared surface. Generation checks prevent stale adapters during Beam replacement.
- **MCP and CLI:** No direct changes. Existing MCP and CLI interfaces remain unchanged. Hermes now follows the same surface-scoped engine path as the working CLI flow.
- **Memory architecture:** No changes to working, episodic, or BEAM tiering. No changes to retrieval, consolidation, or veracity systems.
- **Maintainability:** Centralized lifecycle locking, explicit surface validation, bounded retries, and deterministic regression tests reduce stale-state and adapter race failures.

## Tests

Regression coverage includes:

- Shared-surface push discovery and surface identity.
- Private and foreign-row rejection without mutation.
- Push and pull isolation.
- Per-remote cursor persistence and status reporting.
- Sequential adapter rebinding.
- Lazy construction and reinitialization races.
- Stale adapter shutdown behavior.
- Joined sync-engine error reporting.

This is the right architectural call because Hermes now uses the same surface-scoped engine path as the CLI while preserving local ownership and data isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->