### PR TITLE
docs: pin Hermes runtime Python for wrapper installs

### DIFF
--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -105,6 +105,12 @@ pip install -e "integrations/hermes[dev]"
 >   printf 'Hermes Python is not executable: %s\n' "$HERMES_PYTHON" >&2
 >   exit 1
 > fi
+> # A sibling is trusted only when it activates a real virtual environment.
+> # Otherwise it may be a system/Homebrew Python beside a launcher shim.
+> "$HERMES_PYTHON" -c 'import sys; raise SystemExit(sys.prefix == sys.base_prefix)' || {
+>   printf 'Resolved Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
+>   exit 1
+> }
 > "$HERMES_PYTHON" --version || {
 >   printf 'Hermes Python failed its version probe: %s\n' "$HERMES_PYTHON" >&2
 >   exit 1

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -312,8 +312,42 @@ Use the same selected Hermes Python:
 mode is appropriate for a persistent side virtual environment in deployments
 where that side environment is retained across Hermes updates. It does **not**
 make a direct install into a Hermes-managed virtual environment survive a Hermes
-venv rebuild or replacement. After changing a wrapper, restart or refresh the
-actual local Hermes process before checking provider state.
+venv rebuild or replacement.
+
+#### Windows persistent side-venv wrapper
+
+For a wrapper that survives replacement of the Hermes-managed virtual
+environment, create a **new, empty** side venv with the same Hermes interpreter.
+Do not use bare `uv venv`: it can select a different Python major/minor. The
+commands below refuse to overwrite an existing side venv; choose a new path or
+explicitly retire the old one only after preserving a rollback copy.
+
+```powershell
+$ErrorActionPreference = 'Stop'
+$SideVenv = Join-Path $HermesHome '.mnemosyne\venv'
+if (Test-Path -LiteralPath $SideVenv) {
+    throw "Refusing to replace existing side venv: $SideVenv"
+}
+uv venv --seed --python $HermesPython $SideVenv
+if ($LASTEXITCODE -ne 0) {
+    throw "uv could not create the side venv: $SideVenv"
+}
+$SidePython = Join-Path $SideVenv 'Scripts\python.exe'
+$SideInstaller = Join-Path $SideVenv 'Scripts\mnemosyne-hermes.exe'
+& $SidePython -m pip install "mnemosyne-memory[embeddings]" mnemosyne-hermes
+if ($LASTEXITCODE -ne 0) {
+    throw 'Mnemosyne package installation failed in the side venv'
+}
+& $SideInstaller install --mode wrapper --python $SidePython --no-profile-links
+if ($LASTEXITCODE -ne 0) {
+    throw 'Mnemosyne wrapper installation failed'
+}
+```
+
+`--seed` makes `pip` available in the side venv. If `uv` is unavailable, install
+it or create a side venv by another method that explicitly uses `$HermesPython`;
+do not fall back to an unrelated `python` on `PATH`. After changing a wrapper,
+restart or refresh the actual local Hermes process before checking provider state.
 
 #### Enable and verify
 
@@ -522,12 +556,13 @@ Mnemosyne does not currently expose a standalone REST API server.
 export HERMES_HOME=/opt/data  # Replace with the non-default Hermes home used at install time
 VENV=/path/to/venv             # The same side venv passed to the wrapper install
 hermes memory off  # Disable the external provider; built-in memory remains active
-hermes gateway restart  # Run from a shell outside the gateway process
 "$VENV/bin/mnemosyne-hermes" uninstall
 # For every profile-local wrapper, repeat the uninstall first, with that profile's Hermes home.
 HERMES_HOME=/opt/data/profiles/work "$VENV/bin/mnemosyne-hermes" uninstall
 "$VENV/bin/python" -m pip uninstall mnemosyne-hermes
 ```
+
+For Docker or Compose, restart the actual deployment service with its deployment tooling after removing the wrapper. For a local installation, restart or refresh the actual local Hermes process.
 
 `mnemosyne-hermes uninstall` removes the plugin registration at `$HERMES_HOME/plugins/mnemosyne`. Remove every profile-local wrapper before uninstalling the side-venv package.
 

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -77,38 +77,16 @@ pip install -e "integrations/hermes[dev]"
 >
 > **Docker.** Inside the official Hermes container, the mounted Hermes home is `/opt/data/`, not `~/.hermes/`. Keep the side venv on that mounted volume so both it and the wrapper survive image rebuilds. The side venv must use the same Python **major/minor** as the running Hermes gateway; do not create it with an unrelated `python3` from `PATH`.
 >
-> For a launcher-based Hermes installation, first derive its runtime interpreter from the resolved `hermes` launcher. This bounded launcher-sibling probe covers only that installation shape: it checks the launcher's sibling `python`, then `python3`. It is not a reproduction of the installer's broader internal discovery. If it cannot find a sibling, **stop** and determine the real gateway interpreter from the deployment; do not substitute the current-shell Python or guess another environment.
+> Before creating the venv, obtain the interpreter that starts the **actual running Hermes gateway** from the deployment configuration or container image. Do not infer it from a `hermes` launcher sibling: wrappers and shims can place an unrelated Python next to that command. Set `HERMES_PYTHON` only after verifying that ownership with the deployment operator or runtime configuration; if it cannot be determined, stop.
 >
 > ```bash
-> HERMES_BIN="$(command -v hermes)" || {
->   printf 'Could not find the Hermes launcher on PATH\n' >&2
->   exit 1
-> }
-> HERMES_BIN="$(readlink -f "$HERMES_BIN")" || {
->   printf 'Could not resolve the Hermes launcher\n' >&2
->   exit 1
-> }
-> if [ ! -f "$HERMES_BIN" ] || [ ! -x "$HERMES_BIN" ]; then
->   printf 'Resolved Hermes launcher is not a regular executable file: %s\n' "$HERMES_BIN" >&2
+> : "${HERMES_PYTHON:?Set this to the deployment-verified Python that starts the running Hermes gateway}"
+> if [ ! -f "$HERMES_PYTHON" ] || [ ! -x "$HERMES_PYTHON" ]; then
+>   printf 'Hermes Python is not an executable file: %s\n' "$HERMES_PYTHON" >&2
 >   exit 1
 > fi
-> HERMES_BIN_DIR="$(dirname "$HERMES_BIN")"
-> if [ -f "$HERMES_BIN_DIR/python" ]; then
->   HERMES_PYTHON="$HERMES_BIN_DIR/python"
-> elif [ -f "$HERMES_BIN_DIR/python3" ]; then
->   HERMES_PYTHON="$HERMES_BIN_DIR/python3"
-> else
->   printf 'Could not find Hermes Python beside %s\n' "$HERMES_BIN" >&2
->   exit 1
-> fi
-> if [ ! -x "$HERMES_PYTHON" ]; then
->   printf 'Hermes Python is not executable: %s\n' "$HERMES_PYTHON" >&2
->   exit 1
-> fi
-> # A sibling is trusted only when it activates a real virtual environment.
-> # Otherwise it may be a system/Homebrew Python beside a launcher shim.
 > "$HERMES_PYTHON" -c 'import sys; raise SystemExit(sys.prefix == sys.base_prefix)' || {
->   printf 'Resolved Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
+>   printf 'Hermes Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
 >   exit 1
 > }
 > "$HERMES_PYTHON" --version || {

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -40,6 +40,12 @@ else
   printf 'Could not find Hermes Python beside %s\n' "$HERMES_BIN" >&2
   exit 1
 fi
+# A sibling is trusted only when it activates a real virtual environment.
+# Otherwise it may be a system/Homebrew Python beside a launcher shim.
+"$HERMES_PYTHON" -c 'import sys; raise SystemExit(sys.prefix == sys.base_prefix)' || {
+  printf 'Resolved Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
+  exit 1
+}
 "$HERMES_PYTHON" --version || exit 1
 ```
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -18,18 +18,48 @@
 
 ## Path A: Hermes provider install
 
-For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv. Set `HERMES_HOME` to the directory that contains the active Hermes `config.yaml`; `/opt/data` below is the Docker/image example and must be replaced for other deployments:
+For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv. The side venv must use the same Python **major/minor** as the running Hermes gateway; do not substitute `python3` from `PATH` or run bare `uv venv`, which may select another interpreter.
+
+Set `HERMES_HOME` to the directory that contains the active Hermes `config.yaml`; `/opt/data` below is the Docker/image example and must be replaced for other deployments. First resolve and version-probe the Hermes runtime interpreter. This launcher-sibling probe applies only when the `hermes` launcher and its Python live together; if it cannot find that interpreter, stop and determine the actual gateway Python from the deployment rather than guessing.
 
 ```bash
+HERMES_BIN="$(command -v hermes)" || {
+  printf 'Could not find the Hermes launcher on PATH\n' >&2
+  exit 1
+}
+HERMES_BIN="$(readlink -f "$HERMES_BIN")" || {
+  printf 'Could not resolve the Hermes launcher\n' >&2
+  exit 1
+}
+HERMES_BIN_DIR="$(dirname "$HERMES_BIN")"
+if [ -x "$HERMES_BIN_DIR/python" ]; then
+  HERMES_PYTHON="$HERMES_BIN_DIR/python"
+elif [ -x "$HERMES_BIN_DIR/python3" ]; then
+  HERMES_PYTHON="$HERMES_BIN_DIR/python3"
+else
+  printf 'Could not find Hermes Python beside %s\n' "$HERMES_BIN" >&2
+  exit 1
+fi
+"$HERMES_PYTHON" --version || exit 1
+```
+
+Then create the side venv with that exact interpreter and install the wrapper. Stop on the first failure; do not register or restart a partially installed provider:
+
+```bash
+set -e
 export HERMES_HOME=/opt/data
 VENV="$HERMES_HOME/.mnemosyne/venv"
-python3 -m venv "$VENV"
+"$HERMES_PYTHON" -m venv "$VENV"
+"$VENV/bin/python" -m pip --version
 "$VENV/bin/python" -m pip install --upgrade pip
 "$VENV/bin/python" -m pip install 'mnemosyne-memory[embeddings]' mnemosyne-hermes
 "$VENV/bin/mnemosyne-hermes" install --mode wrapper --python "$VENV/bin/python"
 hermes config set memory.provider mnemosyne
-hermes gateway restart
 ```
+
+If the selected Hermes Python cannot create a usable venv with pip, stop. Do not substitute an arbitrary Python or continue with a partial target. After confirming that `$VENV` is safe to replace, `uv` can create a seeded venv from the same interpreter: `uv venv --clear --seed --python "$HERMES_PYTHON" "$VENV"`. Rerun the pip probe and remaining install commands above only after that command succeeds. For native Windows persistent-side-venv wrapper instructions, use [Native Windows local install and recovery](hermes-integration.md#native-windows-local-install-and-recovery).
+
+For Docker or Compose, restart the actual deployment service using its deployment tooling. Do not substitute `hermes gateway restart` inside the container.
 
 The wrapper installer registers the provider plugin in `$HERMES_HOME/plugins`. Verify the active profile rather than adding a separate `plugins.enabled` entry:
 
@@ -212,7 +242,7 @@ Both Path A's wrapper installer and Path B's `python -m mnemosyne.install` regis
 # Path A: persistent side venv + wrapper
 export HERMES_HOME=/opt/data  # Replace with the active Hermes home
 "$HERMES_HOME/.mnemosyne/venv/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
-hermes gateway restart
+# For Docker or Compose, restart the actual deployment service with its deployment tooling.
 
 # Path B: direct PyPI install
 pip install --upgrade mnemosyne-memory
@@ -235,10 +265,11 @@ Set `HERMES_HOME` to the active Hermes home before removing a Path A wrapper ins
 ```bash
 export HERMES_HOME=/opt/data  # Replace with the active Hermes home
 hermes memory off  # Disable the external provider; built-in memory remains active
-hermes gateway restart  # Run from a shell outside the gateway process
 "$HERMES_HOME/.mnemosyne/venv/bin/mnemosyne-hermes" uninstall
 rm -rf "$HERMES_HOME/.mnemosyne/venv"  # Only if this venv was created by Path A
 ```
+
+For Docker or Compose, restart the actual deployment service with its deployment tooling after the wrapper is removed.
 
 ### Path B or Path D: pip/source install
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -20,30 +20,16 @@
 
 For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv. The side venv must use the same Python **major/minor** as the running Hermes gateway; do not substitute `python3` from `PATH` or run bare `uv venv`, which may select another interpreter.
 
-Set `HERMES_HOME` to the directory that contains the active Hermes `config.yaml`; `/opt/data` below is the Docker/image example and must be replaced for other deployments. First resolve and version-probe the Hermes runtime interpreter. This launcher-sibling probe applies only when the `hermes` launcher and its Python live together; if it cannot find that interpreter, stop and determine the actual gateway Python from the deployment rather than guessing.
+Set `HERMES_HOME` to the directory that contains the active Hermes `config.yaml`; `/opt/data` below is the Docker/image example and must be replaced for other deployments. Before continuing, obtain the interpreter that starts the **actual running Hermes gateway** from the deployment configuration or container image. Do not infer it from a `hermes` launcher sibling: wrappers and shims can place an unrelated Python next to that command. Set `HERMES_PYTHON` only after verifying this ownership with the deployment operator or runtime configuration; if it cannot be determined, stop.
 
 ```bash
-HERMES_BIN="$(command -v hermes)" || {
-  printf 'Could not find the Hermes launcher on PATH\n' >&2
-  exit 1
-}
-HERMES_BIN="$(readlink -f "$HERMES_BIN")" || {
-  printf 'Could not resolve the Hermes launcher\n' >&2
-  exit 1
-}
-HERMES_BIN_DIR="$(dirname "$HERMES_BIN")"
-if [ -x "$HERMES_BIN_DIR/python" ]; then
-  HERMES_PYTHON="$HERMES_BIN_DIR/python"
-elif [ -x "$HERMES_BIN_DIR/python3" ]; then
-  HERMES_PYTHON="$HERMES_BIN_DIR/python3"
-else
-  printf 'Could not find Hermes Python beside %s\n' "$HERMES_BIN" >&2
+: "${HERMES_PYTHON:?Set this to the deployment-verified Python that starts the running Hermes gateway}"
+if [ ! -f "$HERMES_PYTHON" ] || [ ! -x "$HERMES_PYTHON" ]; then
+  printf 'Hermes Python is not an executable file: %s\n' "$HERMES_PYTHON" >&2
   exit 1
 fi
-# A sibling is trusted only when it activates a real virtual environment.
-# Otherwise it may be a system/Homebrew Python beside a launcher shim.
 "$HERMES_PYTHON" -c 'import sys; raise SystemExit(sys.prefix == sys.base_prefix)' || {
-  printf 'Resolved Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
+  printf 'Hermes Python is not a virtual-environment runtime: %s\n' "$HERMES_PYTHON" >&2
   exit 1
 }
 "$HERMES_PYTHON" --version || exit 1


### PR DESCRIPTION
## Why

Issue #933 confirmed that the LLM installation guide still created Path A side venvs with an unqualified `python3`, allowing a persistent wrapper to bridge packages from a different Python major/minor into Hermes. The issue also identified missing Windows persistent-side-venv guidance.

## Change

- Resolve and version-probe the Hermes runtime Python before creating the Docker/image side venv.
- Make the POSIX flow fail closed, use a seeded `uv` fallback tied to that same interpreter, and direct Docker/Compose restarts to deployment tooling.
- Add an explicit, fail-closed Windows persistent-side-venv wrapper path using the selected Hermes Python.
- Align update and uninstall guidance with the Docker restart contract.

## Why not

This PR does not change runtime/provider behavior, auto-rebuild environments, migrate or reindex data, or publish the missing guarded `mnemosyne-hermes` release artifact. Those are separate decisions in #933.

## Verification

- `python3 scripts/generate-docs.py --check`
- `python3 scripts/verify-docs.py`
- `git diff --check`
- Disposable `uv venv --clear --seed --python "$(command -v python3)"` followed by `python -m pip --version`

Closes #933


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Aligns Hermes persistent side virtual environments with the Hermes runtime Python version.
- Adds fail-closed interpreter validation for POSIX and Windows installation flows.
- Updates Docker, Compose, update, and uninstall guidance to use deployment tooling for restarts.
- Does not change Mnemosyne runtime behavior, retrieval, tiered memory, consolidation, veracity, sync, or benchmark systems.
- Preserves local-first and privacy guarantees because the changes affect documentation and environment setup only.
- Clarifies the Hermes integration surface without changing MCP, CLI, or provider APIs.
- Avoids automatic environment rebuilds, data migration, reindexing, or release publication.
- Improves long-term maintainability by preventing Python-version drift and documenting platform-specific recovery paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->