### PR TITLE
feat(hermes): expose runtime Python discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **Hermes runtime-Python discovery (#938).** `mnemosyne-hermes runtime-python --json` reports the validated Python interpreter selected for Hermes, or fails closed when it cannot identify one. `--hermes-home` scopes discovery to that deployment; `--python` explicitly selects an interpreter.
+
 - **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -987,56 +987,48 @@ def _find_hermes_python(
         # or fail to find it at all.
         return Path(selected).expanduser()
 
+    scoped_home = hermes_home_path is not None
     hermes_home_path = (
         Path(hermes_home_path).expanduser()
-        if hermes_home_path is not None
+        if scoped_home
         else hermes_home()
     )
 
-    # 1. Resolve the `hermes` launcher on PATH back to its venv Python.
-    #    A pip/pipx-installed Hermes puts its console script next to the
-    #    interpreter that runs it, so the Python is a sibling of the resolved
-    #    binary. Covers the common /usr/local/lib/hermes-agent/venv layout that
-    #    the hardcoded roots below miss entirely (the silent-no-op that left
-    #    provider deps out of Hermes' actual venv and produced "loaded but no
-    #    provider instance found").
-    #
-    #    The sibling is only trusted when the directory it lives in is a real
-    #    venv. `_resolve_hermes_bin` follows symlinks and wrapper `exec` hops,
-    #    but a launcher that is neither -- a script that calls the real binary
-    #    as a subprocess, or a compiled shim with no `exec` line to read --
-    #    resolves to itself and leaves `bin_dir` as the shim directory. Without
-    #    this check `~/.local/bin/python` (commonly a Homebrew or system
-    #    symlink) gets `mnemosyne-hermes[all]` installed into it while the
-    #    installer reports success (#618). An unvalidated sibling is discarded
-    #    outright rather than kept as a fallback: the only layout it uniquely
-    #    covers is a non-venv system install, which is exactly where
-    #    bootstrapping does the most damage.
-    hermes_bin = shutil.which("hermes")
-    if hermes_bin:
-        resolved = _resolve_hermes_bin(hermes_bin)
-        if resolved:
-            for candidate in _venv_python_candidates(resolved.parent.parent):
-                if _is_validated_venv_python(candidate):
-                    return candidate
+    # An explicit --hermes-home is a discovery boundary. It must never bind the
+    # selected plugin home to a launcher, active venv, or global install that
+    # belongs to another Hermes deployment.
+    if not scoped_home:
+        # 1. Resolve the `hermes` launcher on PATH back to its venv Python.
+        # A pip/pipx-installed Hermes puts its console script next to the
+        # interpreter that runs it, so the Python is a sibling of the resolved
+        # binary. Covers the common /usr/local/lib/hermes-agent/venv layout that
+        # the hardcoded roots below miss entirely.
+        hermes_bin = shutil.which("hermes")
+        if hermes_bin:
+            resolved = _resolve_hermes_bin(hermes_bin)
+            if resolved:
+                for candidate in _venv_python_candidates(resolved.parent.parent):
+                    if _is_validated_venv_python(candidate):
+                        return candidate
 
-    # 2. Check known hermes-agent checkout / install roots with a venv.
-    #    Held to the same bar as the launcher sibling above: a directory named
-    #    `venv` is not evidence that it is one. A half-removed environment, or
-    #    one whose base interpreter is gone, leaves `bin/python` in place with
-    #    no pyvenv.cfg beside it, and bootstrapping into that is the failure
-    #    this function exists to prevent.
-    for root in [
-        hermes_home_path / "hermes-agent",
-        Path.home() / "hermes-agent",
-        Path("/opt/hermes/hermes-agent"),
-        Path("/usr/local/lib/hermes-agent"),
-        Path("/usr/lib/hermes-agent"),
-    ]:
+    # Check the selected Hermes home first. With an explicit home it is the
+    # only permitted root; otherwise retain the established global fallbacks.
+    roots = [hermes_home_path / "hermes-agent"]
+    if not scoped_home:
+        roots.extend([
+            Path.home() / "hermes-agent",
+            Path("/opt/hermes/hermes-agent"),
+            Path("/usr/local/lib/hermes-agent"),
+            Path("/usr/lib/hermes-agent"),
+        ])
+    for root in roots:
         for venv_name in ("venv", ".venv"):
             for candidate in _venv_python_candidates(root / venv_name):
                 if _is_validated_venv_python(candidate):
                     return candidate
+
+    if scoped_home:
+        return None
 
     # 3. Check if we're running inside Hermes' venv ourselves.
     #    `sys.prefix != sys.base_prefix` says the *running* interpreter is in a

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2095,6 +2095,57 @@ def _distribution_version(distribution: str) -> str:
         return "unavailable"
 
 
+def _runtime_python_json_error(message: str) -> int:
+    """Print a runtime Python error using the command's JSON contract."""
+    print(json.dumps({"ok": False, "error": message}))
+    return 1
+
+
+def _runtime_python_json(explicit_python: str | Path | None = None) -> int:
+    """Print the selected Hermes interpreter and version as JSON."""
+    try:
+        python = _find_hermes_python(explicit_python=explicit_python)
+    except ValueError as exc:
+        return _runtime_python_json_error(str(exc))
+
+    if python is None:
+        return _runtime_python_json_error(
+            "Could not identify Hermes' Python. Pass --python "
+            "/path/to/hermes/venv/bin/python."
+        )
+    if not python.is_file() or not os.access(python, os.X_OK):
+        return _runtime_python_json_error(
+            f"Selected Python is not an executable file: {python}"
+        )
+
+    try:
+        result = subprocess.run(
+            [
+                str(python),
+                "-I",
+                "-S",
+                "-c",
+                "import platform; print(platform.python_version())",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return _runtime_python_json_error(f"Could not run selected Python at {python}: {exc}")
+
+    version = result.stdout.strip()
+    if result.returncode != 0 or not version:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        return _runtime_python_json_error(
+            f"Could not read Python version from {python}: {detail}"
+        )
+
+    print(json.dumps({"ok": True, "python": str(python), "version": version}))
+    return 0
+
+
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -2184,6 +2235,20 @@ def _parser() -> argparse.ArgumentParser:
         help="Show whether Mnemosyne is installed for Hermes memory discovery.",
     )
     subparsers.add_parser("version", help="Show installed package versions.")
+    runtime_python = subparsers.add_parser(
+        "runtime-python",
+        help="Report the Python interpreter selected for Hermes.",
+    )
+    runtime_python.add_argument(
+        "--json",
+        action="store_true",
+        required=True,
+        help="Emit the selected interpreter and version as JSON.",
+    )
+    runtime_python.add_argument(
+        "--python",
+        help="Explicit Hermes Python interpreter; bypasses automatic discovery.",
+    )
     cleanup = subparsers.add_parser(
         "cleanup",
         help="Remove all traces of Mnemosyne from Hermes plugin directory (safe, never touches database).",
@@ -2532,6 +2597,9 @@ def main(argv: list[str] | None = None) -> int:
                 print("  → Hermes Python vs install Python mismatch means the symlink exists but Hermes")
                 print("     may not be able to import mnemosyne core. Run with --dry-run to diagnose.")
             return 0 if installed else 1
+
+        if command == "runtime-python":
+            return _runtime_python_json(explicit_python=args.python)
 
         if command == "cleanup":
             dry_run = getattr(args, "dry_run", False)

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -948,8 +948,14 @@ def _validate_explicit_python(explicit_python: str | Path | None) -> None:
         )
 
 
-def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[Path]:
-    """Try to find Hermes' python executable for dep validation.
+def _find_hermes_python(
+    explicit_python: str | Path | None = None,
+    hermes_home_path: str | Path | None = None,
+) -> Optional[Path]:
+    """Try to find Hermes' Python executable for dependency validation.
+
+    ``hermes_home_path`` scopes known-root discovery to an explicit CLI home;
+    otherwise the configured default Hermes home is used.
 
     Returns None when no *validated* Hermes runtime is found. A candidate is
     never returned on the strength of sitting next to the launcher alone: the
@@ -981,7 +987,11 @@ def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[P
         # or fail to find it at all.
         return Path(selected).expanduser()
 
-    hermes_home_path = hermes_home()
+    hermes_home_path = (
+        Path(hermes_home_path).expanduser()
+        if hermes_home_path is not None
+        else hermes_home()
+    )
 
     # 1. Resolve the `hermes` launcher on PATH back to its venv Python.
     #    A pip/pipx-installed Hermes puts its console script next to the
@@ -2101,10 +2111,16 @@ def _runtime_python_json_error(message: str) -> int:
     return 1
 
 
-def _runtime_python_json(explicit_python: str | Path | None = None) -> int:
+def _runtime_python_json(
+    explicit_python: str | Path | None = None,
+    hermes_home_path: str | Path | None = None,
+) -> int:
     """Print the selected Hermes interpreter and version as JSON."""
     try:
-        python = _find_hermes_python(explicit_python=explicit_python)
+        python = _find_hermes_python(
+            explicit_python=explicit_python,
+            hermes_home_path=hermes_home_path,
+        )
     except ValueError as exc:
         return _runtime_python_json_error(str(exc))
 
@@ -2124,8 +2140,13 @@ def _runtime_python_json(explicit_python: str | Path | None = None) -> int:
                 str(python),
                 "-I",
                 "-S",
+                "-B",
                 "-c",
-                "import platform; print(platform.python_version())",
+                (
+                    "import json, platform; "
+                    "print(json.dumps({'runtime': 'python', "
+                    "'version': platform.python_version()}))"
+                ),
             ],
             capture_output=True,
             text=True,
@@ -2135,9 +2156,21 @@ def _runtime_python_json(explicit_python: str | Path | None = None) -> int:
     except (OSError, subprocess.TimeoutExpired) as exc:
         return _runtime_python_json_error(f"Could not run selected Python at {python}: {exc}")
 
-    version = result.stdout.strip()
-    if result.returncode != 0 or not version:
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        payload = None
+    version = payload.get("version") if isinstance(payload, dict) else None
+    if (
+        result.returncode != 0
+        or not isinstance(payload, dict)
+        or payload.get("runtime") != "python"
+        or not isinstance(version, str)
+        or not version
+    ):
         detail = result.stderr.strip() or f"exit status {result.returncode}"
+        if result.returncode == 0 and not result.stderr.strip():
+            detail = "unexpected runtime probe response"
         return _runtime_python_json_error(
             f"Could not read Python version from {python}: {detail}"
         )
@@ -2309,7 +2342,10 @@ def run_install(
     # Both install modes need a Hermes interpreter. Symlink installs bootstrap
     # it when needed; wrapper installs validate it and record its metadata. An
     # explicit --python remains authoritative through _find_hermes_python().
-    hermes_python = _find_hermes_python(explicit_python=python)
+    hermes_python = _find_hermes_python(
+        explicit_python=python,
+        hermes_home_path=hermes_home_path,
+    )
     if mode == "wrapper" and hermes_python is None:
         print(
             "\n  ⚠ Could not identify Hermes' Python for wrapper mode.\n"
@@ -2449,7 +2485,8 @@ def main(argv: list[str] | None = None) -> int:
 
             # Dry-run: just show what would happen
             hermes_python = _find_hermes_python(
-                explicit_python=getattr(args, "python", None)
+                explicit_python=getattr(args, "python", None),
+                hermes_home_path=args.hermes_home,
             )
             if args.mode == "wrapper" and hermes_python is None:
                 print(
@@ -2543,7 +2580,7 @@ def main(argv: list[str] | None = None) -> int:
             state = plugin_state(hermes_home_path=args.hermes_home)
             target = state.target
             installed = state.installed
-            hermes_python = _find_hermes_python()
+            hermes_python = _find_hermes_python(hermes_home_path=args.hermes_home)
             print("Status for mnemosyne-hermes plugin")
             print(f"  Plugin path: {target}")
             print(f"  State: {state.status}")
@@ -2599,7 +2636,10 @@ def main(argv: list[str] | None = None) -> int:
             return 0 if installed else 1
 
         if command == "runtime-python":
-            return _runtime_python_json(explicit_python=args.python)
+            return _runtime_python_json(
+                explicit_python=args.python,
+                hermes_home_path=args.hermes_home,
+            )
 
         if command == "cleanup":
             dry_run = getattr(args, "dry_run", False)

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -1123,6 +1123,34 @@ def test_default_symlink_retains_cli_core_preflight(tmp_path, monkeypatch, capsy
     assert "mnemosyne-memory NOT found in this Python" in capsys.readouterr().err
 
 
+def test_explicit_hermes_home_excludes_path_launcher(tmp_path, monkeypatch):
+    """A scoped home wins over a different valid Hermes launcher on PATH."""
+    selected_home = tmp_path / "selected-home"
+    selected_python = _make_venv(selected_home / "hermes-agent" / "venv")
+
+    other_venv = tmp_path / "other-hermes-venv"
+    _make_venv(other_venv)
+    _write_executable(other_venv / "bin" / "hermes", "#!/bin/sh\nexit 0\n")
+    monkeypatch.setenv("PATH", str(other_venv / "bin"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+
+    assert install._find_hermes_python(hermes_home_path=selected_home) == selected_python
+
+
+def test_explicit_hermes_home_fails_closed_without_its_runtime(tmp_path, monkeypatch):
+    """A scoped home cannot fall back to an unrelated valid launcher on PATH."""
+    selected_home = tmp_path / "selected-home"
+    other_venv = tmp_path / "other-hermes-venv"
+    _make_venv(other_venv)
+    _write_executable(other_venv / "bin" / "hermes", "#!/bin/sh\nexit 0\n")
+    monkeypatch.setenv("PATH", str(other_venv / "bin"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+
+    assert install._find_hermes_python(hermes_home_path=selected_home) is None
+
+
 def _make_windows_venv(root: Path) -> Path:
     """Create a native Windows venv layout without changing ``os.name``."""
     scripts = root / "Scripts"

--- a/integrations/hermes/tests/test_runtime_python_cli.py
+++ b/integrations/hermes/tests/test_runtime_python_cli.py
@@ -1,0 +1,70 @@
+"""Tests for the read-only ``runtime-python`` installer command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from mnemosyne_hermes import install
+
+
+def test_runtime_python_json_reports_discovered_interpreter(monkeypatch, capsys):
+    selected = Path("/opt/hermes/venv/bin/python")
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: selected)
+    monkeypatch.setattr(Path, "is_file", lambda self: True)
+    monkeypatch.setattr(install.os, "access", lambda path, mode: True)
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "3.12.13\n", ""),
+    )
+
+    assert install.main(["runtime-python", "--json"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "python": str(selected),
+        "version": "3.12.13",
+    }
+
+
+def test_runtime_python_json_passes_explicit_python_unchanged(monkeypatch, capsys):
+    selected = "/a path/with trailing space/python "
+    received = []
+
+    def find_python(*, explicit_python=None):
+        received.append(explicit_python)
+        return Path(selected)
+
+    monkeypatch.setattr(install, "_find_hermes_python", find_python)
+    monkeypatch.setattr(Path, "is_file", lambda self: True)
+    monkeypatch.setattr(install.os, "access", lambda path, mode: True)
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "3.13.5\n", ""),
+    )
+
+    assert install.main(["runtime-python", "--json", "--python", selected]) == 0
+
+    assert received == [selected]
+    assert json.loads(capsys.readouterr().out)["python"] == selected
+
+
+def test_runtime_python_json_fails_closed_when_discovery_fails(monkeypatch, capsys):
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: None)
+
+    assert install.main(["runtime-python", "--json"]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "Could not identify Hermes' Python" in payload["error"]
+
+
+def test_runtime_python_json_fails_closed_for_empty_explicit_python(capsys):
+    assert install.main(["runtime-python", "--json", "--python", " "]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "empty value" in payload["error"]

--- a/integrations/hermes/tests/test_runtime_python_cli.py
+++ b/integrations/hermes/tests/test_runtime_python_cli.py
@@ -14,14 +14,22 @@ def test_runtime_python_json_reports_discovered_interpreter(monkeypatch, capsys)
     monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: selected)
     monkeypatch.setattr(Path, "is_file", lambda self: True)
     monkeypatch.setattr(install.os, "access", lambda path, mode: True)
+    probe_commands = []
     monkeypatch.setattr(
         install.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "3.12.13\n", ""),
+        lambda *args, **kwargs: (
+            probe_commands.append(args[0])
+            or subprocess.CompletedProcess(
+                args[0], 0, '{"runtime": "python", "version": "3.12.13"}\n', ""
+            )
+        ),
     )
 
     assert install.main(["runtime-python", "--json"]) == 0
 
+    assert len(probe_commands) == 1
+    assert probe_commands[0][:5] == [str(selected), "-I", "-S", "-B", "-c"]
     assert json.loads(capsys.readouterr().out) == {
         "ok": True,
         "python": str(selected),
@@ -33,8 +41,8 @@ def test_runtime_python_json_passes_explicit_python_unchanged(monkeypatch, capsy
     selected = "/a path/with trailing space/python "
     received = []
 
-    def find_python(*, explicit_python=None):
-        received.append(explicit_python)
+    def find_python(*, explicit_python=None, hermes_home_path=None):
+        received.append((explicit_python, hermes_home_path))
         return Path(selected)
 
     monkeypatch.setattr(install, "_find_hermes_python", find_python)
@@ -43,13 +51,62 @@ def test_runtime_python_json_passes_explicit_python_unchanged(monkeypatch, capsy
     monkeypatch.setattr(
         install.subprocess,
         "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "3.13.5\n", ""),
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, '{"runtime": "python", "version": "3.13.5"}\n', ""
+        ),
     )
 
     assert install.main(["runtime-python", "--json", "--python", selected]) == 0
 
-    assert received == [selected]
+    assert received == [(selected, None)]
     assert json.loads(capsys.readouterr().out)["python"] == selected
+
+
+def test_runtime_python_json_forwards_explicit_hermes_home(monkeypatch, capsys):
+    selected = Path("/custom/hermes/venv/bin/python")
+    received = []
+
+    def find_python(**kwargs):
+        received.append(kwargs)
+        return selected
+
+    monkeypatch.setattr(install, "_find_hermes_python", find_python)
+    monkeypatch.setattr(Path, "is_file", lambda self: True)
+    monkeypatch.setattr(install.os, "access", lambda path, mode: True)
+    probe_commands = []
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda *args, **kwargs: (
+            probe_commands.append(args[0])
+            or subprocess.CompletedProcess(
+                args[0], 0, '{"runtime": "python", "version": "3.12.13"}\n', ""
+            )
+        ),
+    )
+
+    assert install.main(["--hermes-home", "/custom/hermes", "runtime-python", "--json"]) == 0
+
+    assert received == [{"explicit_python": None, "hermes_home_path": "/custom/hermes"}]
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_runtime_python_json_rejects_non_python_probe_output(monkeypatch, capsys):
+    selected = Path("/not/python")
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: selected)
+    monkeypatch.setattr(Path, "is_file", lambda self: True)
+    monkeypatch.setattr(install.os, "access", lambda path, mode: True)
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "not Python\n", ""),
+    )
+
+    assert install.main(["runtime-python", "--json"]) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "unexpected runtime probe response" in payload["error"]
 
 
 def test_runtime_python_json_fails_closed_when_discovery_fails(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add a read-only `mnemosyne-hermes runtime-python --json` command
- reuse the existing validated `_find_hermes_python()` discovery contract
- emit a stable JSON success/error result and never install, mutate config, or activate an environment

## Verification
- `MNEMOSYNE_NO_EMBEDDINGS=1 integrations/hermes/.venv/bin/python -m pytest integrations/hermes/tests/test_runtime_python_cli.py integrations/hermes/tests/test_find_hermes_python.py integrations/hermes/tests/test_install_cli_entrypoint.py -q`
  - 72 passed (2 existing pytest config warnings)
- real command: `python -m mnemosyne_hermes.install runtime-python --json --python "$(command -v python3)"`
  - returned `{"ok": true, "python": "/usr/bin/python3", "version": "3.13.5"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds the read-only `mnemosyne-hermes runtime-python --json` command.

- Reuses `_find_hermes_python()` for validated interpreter discovery.
- Supports Hermes-home scoping and explicit interpreter selection.
- Reports the interpreter path and Python version as stable JSON.
- Returns structured error JSON with exit code 1 on failure.
- Does not install packages, change configuration, activate environments, or access memory data.
- Adds targeted tests for discovery, selection, scoping, and failure handling.

## Architectural Impact

- Adds a machine-readable Hermes CLI integration surface.
- Preserves local-first execution and privacy because runtime probing occurs locally.
- Does not change working, episodic, or BEAM memory tiers.
- Does not change retrieval, consolidation, veracity, sync, MCP, or benchmark methodology.
- Reuses the validated discovery contract for consistent behavior and easier maintenance. This is the right call.
- The change does not erode local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->