### PR TITLE
fix(sync): reject unsafe sync-init targets before initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,8 +443,11 @@ mnemosyne sync-serve --db-path "$SURFACE" --port 8765 \
 mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765
 
 # With client-side encryption
-export MNEMOSYNE_SYNC_KEY=$(mnemosyne sync-generate-key)
-mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 --encrypt
+SYNC_KEY_FILE="$HOME/.config/mnemosyne/sync-encryption.key"
+mkdir -p "$(dirname "$SYNC_KEY_FILE")"
+(umask 077 && mnemosyne sync-generate-key > "$SYNC_KEY_FILE")
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 \
+  --encrypt-key-file "$SYNC_KEY_FILE"
 
 # Check sync status
 mnemosyne sync-status --db-path "$SURFACE" --remote https://my-vps:8765

--- a/README.md
+++ b/README.md
@@ -430,19 +430,30 @@ Bidirectional, delta-based memory sync between Mnemosyne instances. Designed for
 - Append-only event log for auditability
 
 ```bash
-# Start a sync server on your VPS
-mnemosyne sync-serve --port 8765 --api-key "your-secret-key"
+# Create a physically dedicated shared-surface DB (never your private Hermes DB)
+SURFACE="$HOME/.hermes/mnemosyne/data/shared/mnemosyne.db"
+mkdir -p "$(dirname "$SURFACE")"
+mnemosyne sync-init --db-path "$SURFACE"
+
+# Start a sync server on that dedicated surface
+mnemosyne sync-serve --db-path "$SURFACE" --port 8765 \
+  --api-key "your-secret-key"
 
 # On your local machine, sync bidirectionally
-mnemosyne sync --remote https://my-vps:8765
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765
 
 # With client-side encryption
 export MNEMOSYNE_SYNC_KEY=$(mnemosyne sync-generate-key)
-mnemosyne sync --remote https://my-vps:8765 --encrypt
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 --encrypt
 
 # Check sync status
-mnemosyne sync-status --remote https://my-vps:8765
+mnemosyne sync-status --db-path "$SURFACE" --remote https://my-vps:8765
 ```
+
+The shared surface is populated only through the explicit `mnemosyne_shared_*`
+Hermes tools. Setting `default_scope: global` changes the default scope for new
+private-database writes; it does not convert existing private/session history,
+copy it into the surface, or make a regular Hermes database safe to sync.
 
 **When encryption is enabled**, the remote server sees only metadata (event IDs, timestamps, operation types). Memory content is encrypted before leaving your machine and can only be decrypted with your key.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -73,7 +73,7 @@ Import is idempotent: annotation collisions are skipped rather than aborting the
 | Command | Usage |
 |---|---|
 | `sync-init` | `sync-init --db-path <path> [--claim-existing --yes]`. Prepares a dedicated shared-surface database |
-| `sync` | `sync --db-path <path> --remote <url> [--mode push\|pull\|bidirectional]` |
+| `sync` | `sync --db-path <path> --remote <url> [--mode push\|pull\|bidirectional] [--encrypt <key>\|--encrypt-key-file <path>] [--api-key <key>\|--api-key-file <path>]` |
 | `sync-serve`, `sync-server` | `sync-serve --db-path <path> [--port 8765] [--host 127.0.0.1] [--api-key\|--api-key-file] [--jwt-secret\|--jwt-secret-file] [--tls-cert --tls-key]` |
 | `sync-status` | `sync-status --db-path <path> [--remote <url>] [--json]` |
 | `sync-generate-key` | Prints a fresh encryption key |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -115,11 +115,29 @@ Each exchange is idempotent &mdash; events carry unique `event_id`s and are dedu
 - Network connectivity between instances (or via SSH tunnel)
 - (Recommended) TLS certificate for the remote endpoint
 
+### Dedicated shared surface required
+
+Sync operates only on a physically dedicated shared-surface database. Never
+point `sync-init`, `sync`, or `sync-serve` at the regular Hermes memory DB. A
+safe initial path is:
+
+```bash
+SURFACE="$HOME/.hermes/mnemosyne/data/shared/mnemosyne.db"
+mkdir -p "$(dirname "$SURFACE")"
+mnemosyne sync-init --db-path "$SURFACE"
+```
+
+Hermes populates this surface through the explicit `mnemosyne_shared_*` tools.
+No command here automatically migrates, exports, or copies private/session
+history. In particular, `default_scope: global` only changes the default scope
+of new writes; it does not turn a regular Hermes DB into a shared surface.
+
 ### 1. Set Up the Remote Instance
 
 ```bash
 # On your VPS / remote machine
-mnemosyne sync-serve --port 8765 --api-key "your-secret-api-key"
+mnemosyne sync-serve --db-path "$SURFACE" --port 8765 \
+  --api-key "your-secret-api-key"
 ```
 
 This starts a sync server listening on port 8765.
@@ -133,20 +151,23 @@ This starts a sync server listening on port 8765.
 export MNEMOSYNE_SYNC_TOKEN="your-secret-api-key"
 
 # Test the connection
-mnemosyne sync-status --remote https://my-vps.example.com:8765
+mnemosyne sync-status --db-path "$SURFACE" \
+  --remote https://my-vps.example.com:8765
 ```
 
 ### 3. Run a Sync
 
 ```bash
 # Bidirectional sync (default)
-mnemosyne sync --remote https://my-vps.example.com:8765
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps.example.com:8765
 
 # Pull only (fetch remote changes without pushing local)
-mnemosyne sync --remote https://my-vps.example.com:8765 --mode pull
+mnemosyne sync --db-path "$SURFACE" \
+  --remote https://my-vps.example.com:8765 --mode pull
 
 # Push only (send local changes without fetching)
-mnemosyne sync --remote https://my-vps.example.com:8765 --mode push
+mnemosyne sync --db-path "$SURFACE" \
+  --remote https://my-vps.example.com:8765 --mode push
 ```
 
 ### 4. With Client-Side Encryption

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -173,12 +173,13 @@ mnemosyne sync --db-path "$SURFACE" \
 ### 4. With Client-Side Encryption
 
 ```bash
-# Generate an encryption key
-mnemosyne sync-generate-key > mnemosyne-sync.key
+# Generate a private encryption-key file
+(umask 077 && mnemosyne sync-generate-key > mnemosyne-sync.key)
 
 # Sync with encryption
-MNEMOSYNE_SYNC_KEY=$(cat mnemosyne-sync.key) \
-  mnemosyne sync --remote https://my-vps.example.com:8765 --encrypt
+mnemosyne sync --db-path "$SURFACE" \
+  --remote https://my-vps.example.com:8765 \
+  --encrypt-key-file mnemosyne-sync.key
 ```
 
 ---
@@ -193,13 +194,17 @@ Usage: mnemosyne sync [OPTIONS]
 Synchronize memories with a remote Mnemosyne instance.
 
 Options:
-  --remote TEXT          Remote URL (e.g., https://my-vps:8765)  [required]
-  --mode TEXT            Sync mode: bidirectional, pull, push  [default: bidirectional]
-  --encrypt              Enable client-side payload encryption
-  --prompt-key           Prompt for encryption key interactively
-  --api-key TEXT         API key for remote authentication
-  --interval SECONDS     Continuous sync interval (0 = one-shot)  [default: 0]
-  --help                 Show this message and exit
+  --remote REMOTE                       Remote sync server URL  [required]
+  --db-path DB_PATH                     Dedicated shared-surface DB  [required]
+  --session-id SESSION_ID               Stable shared-surface session ID
+  --mode {push,pull,bidirectional}       Sync direction
+  --encrypt ENCRYPT                     Encryption key (visible in process arguments)
+  --encrypt-key-file ENCRYPT_KEY_FILE   Private file containing the encryption key
+  --api-key API_KEY                     API key (visible in process arguments)
+  --api-key-file API_KEY_FILE           Private file containing the API key
+  --interval INTERVAL                   Repeat interval in seconds
+  --initialize-surface                  Explicitly initialize a new dedicated surface
+  -h, --help                            Show this message and exit
 
 Security Notice:
   ╔════════════════════════════════════════════════════════╗
@@ -225,13 +230,19 @@ Usage: mnemosyne sync-serve [OPTIONS]
 Start a sync server for remote Mnemosyne instances.
 
 Options:
-  --port INTEGER          Port to listen on  [default: 8765]
-  --host TEXT             Host to bind to  [default: 127.0.0.1]
-  --api-key TEXT          API key for authentication  [default: none]
-  --jwt-secret TEXT       JWT secret for authentication  [default: none]
-  --tls-cert TEXT         Path to TLS certificate file
-  --tls-key TEXT          Path to TLS key file
-  --help                  Show this message and exit
+  --port PORT                         Server port
+  --host HOST                         Bind address
+  --db-path DB_PATH                   Relay SQLite DB  [required]
+  --initialize-surface                Initialize a new dedicated relay DB
+  --behind-tls-proxy                  Allow cleartext behind a trusted TLS proxy
+  --api-key API_KEY                   Bearer-token API key
+  --api-key-file API_KEY_FILE         Private file containing the API key
+  --jwt-secret JWT_SECRET             JWT secret
+  --jwt-secret-file JWT_SECRET_FILE   Private file containing the JWT secret
+  --tls-cert TLS_CERT                 TLS certificate file
+  --tls-key TLS_KEY                   TLS key file
+  --device-id DEVICE_ID               Custom device identifier
+  -h, --help                          Show this message and exit
 ```
 
 ### `mnemosyne sync-status`
@@ -242,10 +253,12 @@ Usage: mnemosyne sync-status [OPTIONS]
 Show sync status with a remote instance.
 
 Options:
-  --remote TEXT    Remote URL  [required]
-  --api-key TEXT   API key for authentication
-  --json           Output as JSON
-  --help           Show this message and exit
+  --db-path DB_PATH               Shared-surface SQLite DB  [required]
+  --remote REMOTE                 Remote URL to check
+  --api-key API_KEY               API key
+  --api-key-file API_KEY_FILE     Private file containing the API key
+  --json                          Output as JSON
+  -h, --help                      Show this message and exit
 
 Example output:
   Sync Status
@@ -269,10 +282,11 @@ Usage: mnemosyne sync-generate-key
 
 Generate a random 32-byte key for client-side encryption.
 
-Outputs a base64-encoded key suitable for MNEMOSYNE_SYNC_KEY.
+Outputs a base64-encoded key suitable for `--encrypt` or a private
+`--encrypt-key-file`.
 
 Example:
-  export MNEMOSYNE_SYNC_KEY=$(mnemosyne sync-generate-key)
+  (umask 077 && mnemosyne sync-generate-key > mnemosyne-sync.key)
 ```
 
 ---
@@ -374,11 +388,12 @@ The simplest authentication method. Passed as `Authorization: Bearer <key>` head
 
 ```bash
 # Server side
-mnemosyne sync-serve --api-key "sk-mnemo-abc123"
+mnemosyne sync-serve --db-path "$SURFACE" --api-key "sk-mnemo-abc123"
 
 # Client side
 export MNEMOSYNE_SYNC_TOKEN="sk-mnemo-abc123"
-mnemosyne sync --remote https://my-vps:8765
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 \
+  --api-key "$MNEMOSYNE_SYNC_TOKEN"
 ```
 
 ### JWT
@@ -387,10 +402,11 @@ For multi-user setups or integration with existing auth systems.
 
 ```bash
 # Server side
-mnemosyne sync-serve --jwt-secret "your-jwt-secret"
+mnemosyne sync-serve --db-path "$SURFACE" --jwt-secret "your-jwt-secret"
 
 # Client side
-MNEMOSYNE_SYNC_JWT="<token>" mnemosyne sync --remote https://my-vps:8765
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 \
+  --api-key "<JWT token>"
 ```
 
 ---
@@ -402,16 +418,12 @@ See [docs/security.md](security.md#encryption-in-mnemosyne-sync) for the full en
 ### Quick Reference
 
 ```bash
-# Generate a key
-mnemosyne sync-generate-key
+# Generate a private key file
+(umask 077 && mnemosyne sync-generate-key > mnemosyne-sync.key)
 
 # Sync with encryption
-export MNEMOSYNE_SYNC_KEY="<base64-key>"
-mnemosyne sync --remote https://my-vps:8765 --encrypt
-
-# Or use a passphrase (key derived automatically)
-export MNEMOSYNE_SYNC_PASSPHRASE="your strong passphrase"
-mnemosyne sync --remote https://my-vps:8765 --encrypt
+mnemosyne sync --db-path "$SURFACE" --remote https://my-vps:8765 \
+  --encrypt-key-file mnemosyne-sync.key
 ```
 
 ### Dependencies
@@ -450,7 +462,8 @@ services:
       - MNEMOSYNE_SYNC_KEY_FILE=/run/secrets/sync.key
     command: >
       sh -c "pip install -q mnemosyne-memory[sync] &&
-             mnemosyne sync-serve --port 8765 --api-key $(cat /run/secrets/sync.key)"
+             mnemosyne sync-serve --db-path /data/relay.db --initialize-surface
+             --port 8765 --api-key $(cat /run/secrets/sync.key)"
 
 volumes:
   mnemosyne-data:
@@ -524,10 +537,11 @@ If you don't want to expose the sync port publicly:
 ssh -L 8765:localhost:8765 user@your-vps
 
 # On your VPS
-mnemosyne sync-serve --port 8765 --host 127.0.0.1 --api-key "..."
+mnemosyne sync-serve --db-path "$SURFACE" --port 8765 \
+  --host 127.0.0.1 --api-key "..."
 
 # On your local machine (tunnel active)
-mnemosyne sync --remote http://localhost:8765
+mnemosyne sync --db-path "$SURFACE" --remote http://localhost:8765
 ```
 
 ### Ready-to-Use Configs

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -726,13 +726,93 @@ def _read_secret_file(path: str, label: str) -> str:
 
 _DEFAULT_SYNC_SESSION_ID = "hermes_shared_surface"
 
+_SYNC_DEDICATED_DB_RECOVERY = (
+    "The supplied database is not a dedicated shared-surface database. "
+    "Use a new path, for example: `mnemosyne sync-init --db-path "
+    '"$HOME/.hermes/mnemosyne/data/shared/mnemosyne.db"`. '
+    "Populate that database through `mnemosyne_shared_*`; private/session "
+    "history is not copied automatically."
+)
+
+
+def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, int]:
+    """Classify an existing sync-init target without changing SQLite state."""
+    import sqlite3
+
+    path = Path(db_path).expanduser()
+    if not path.exists():
+        return 0, 0
+    if not path.is_file():
+        raise SystemExit(f"Refusing initialization: {path} is not a database file")
+
+    # A hot WAL/journal cannot be inspected with immutable=1, while opening it
+    # normally may create or update sidecars. Fail closed instead.
+    for suffix in ("-wal", "-journal"):
+        sidecar = Path(f"{path}{suffix}")
+        try:
+            has_uncheckpointed_state = sidecar.exists() and sidecar.stat().st_size > 0
+        except OSError as error:
+            raise SystemExit(
+                f"Refusing initialization: cannot inspect SQLite sidecar read-only: {error}"
+            ) from None
+        if has_uncheckpointed_state:
+            raise SystemExit(
+                "Refusing initialization: the target has uncheckpointed SQLite "
+                f"state. Close/checkpoint it before retrying. {_SYNC_DEDICATED_DB_RECOVERY}"
+            )
+
+    # immutable=1 prevents even a read-only SQLite connection from creating
+    # WAL/SHM files while it inspects a quiescent existing target.
+    uri = f"{path.resolve().as_uri()}?mode=ro&immutable=1"
+    try:
+        conn = sqlite3.connect(uri, uri=True)
+        try:
+            conn.execute("PRAGMA query_only=ON")
+            table_exists = conn.execute(
+                """SELECT 1 FROM sqlite_master
+                   WHERE type = 'table' AND name = 'working_memory'"""
+            ).fetchone()
+            if table_exists is None:
+                return 0, 0
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(working_memory)")
+            }
+            if not {"scope", "session_id"}.issubset(columns):
+                raise SystemExit(f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}")
+            existing_rows = conn.execute(
+                "SELECT COUNT(*) FROM working_memory"
+            ).fetchone()[0]
+            invalid_rows = conn.execute(
+                """SELECT COUNT(*) FROM working_memory
+                   WHERE scope != 'global' OR session_id != ?""",
+                (session_id,),
+            ).fetchone()[0]
+            return existing_rows, invalid_rows
+        finally:
+            conn.close()
+    except SystemExit:
+        raise
+    except sqlite3.Error as error:
+        raise SystemExit(
+            f"Refusing initialization: cannot validate the target read-only: {error}"
+        ) from None
+
 
 def cmd_sync_init(args):
     """Explicitly initialize or migrate a dedicated shared-surface DB."""
     import argparse
 
-    parser = argparse.ArgumentParser(prog="mnemosyne sync-init")
-    parser.add_argument("--db-path", required=True, help="Dedicated shared-surface DB")
+    parser = argparse.ArgumentParser(
+        prog="mnemosyne sync-init",
+        description="Initialize a physically dedicated shared-surface database.",
+        epilog=(
+            "Do not use a private/session database. Populate the dedicated "
+            "surface through mnemosyne_shared_*; private history is not copied."
+        ),
+    )
+    parser.add_argument(
+        "--db-path", required=True, help="New or dedicated shared-surface DB"
+    )
     parser.add_argument(
         "--session-id",
         default=_DEFAULT_SYNC_SESSION_ID,
@@ -750,28 +830,22 @@ def cmd_sync_init(args):
     )
     parsed = parser.parse_args(args)
 
+    existing_rows, invalid_rows = _sync_init_readonly_preflight(
+        parsed.db_path, parsed.session_id
+    )
+    if invalid_rows:
+        raise SystemExit(f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}")
+
     from mnemosyne.core.memory import Mnemosyne
     from mnemosyne.core.sync import SyncEngine
 
     mem = Mnemosyne(db_path=parsed.db_path, session_id=parsed.session_id)
-    existing_rows = mem.beam.conn.execute(
-        "SELECT COUNT(*) FROM working_memory"
-    ).fetchone()[0]
-    invalid_rows = mem.beam.conn.execute(
-        """SELECT COUNT(*) FROM working_memory
-           WHERE scope != 'global' OR session_id != ?""",
-        (parsed.session_id,),
-    ).fetchone()[0]
     preview = {
         "db_path": str(parsed.db_path),
         "session_id": parsed.session_id,
         "existing_rows": existing_rows,
         "invalid_rows": invalid_rows,
     }
-    if invalid_rows:
-        raise SystemExit(
-            "Refusing migration: DB contains non-global or foreign-session rows"
-        )
     if existing_rows and not (parsed.claim_existing and parsed.yes):
         preview["status"] = "confirmation_required"
         preview["required_flags"] = ["--claim-existing", "--yes"]
@@ -1838,7 +1912,7 @@ def run_cli():
         # machine-readable code, never a traceback (which leaks absolute
         # paths and library internals into logs).
         try:
-            if command not in {"doctor", "repair"}:
+            if command not in {"doctor", "repair", "sync-init"}:
                 os.makedirs(DATA_DIR, exist_ok=True)
             handler(sys.argv[2:])
         except SystemExit:

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -735,18 +735,40 @@ _SYNC_DEDICATED_DB_RECOVERY = (
 )
 
 
-def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, int]:
-    """Classify an existing sync-init target without changing SQLite state."""
+def _sync_init_readonly_preflight(
+    db_path: str, session_id: str
+) -> tuple[Path, int, int]:
+    """Classify a sync-init target and return the identity later opened."""
     import sqlite3
 
-    path = Path(db_path).expanduser()
-    if not path.exists():
-        return 0, 0
-    if not path.is_file():
-        raise SystemExit(f"Refusing initialization: {path} is not a database file")
+    supplied_path = Path(db_path).expanduser()
+    if supplied_path.is_symlink():
+        raise SystemExit(
+            "Refusing initialization: symbolic-link database targets are not allowed"
+        )
+    if not supplied_path.exists():
+        return supplied_path.resolve(), 0, 0
+    if not supplied_path.is_file():
+        raise SystemExit(
+            f"Refusing initialization: {supplied_path} is not a database file"
+        )
+
+    try:
+        path = supplied_path.resolve(strict=True)
+        if path.stat().st_nlink > 1:
+            raise SystemExit(
+                "Refusing initialization: multiply-linked database targets are not allowed"
+            )
+    except SystemExit:
+        raise
+    except OSError as error:
+        raise SystemExit(
+            f"Refusing initialization: cannot establish database identity: {error}"
+        ) from None
 
     # A hot WAL/journal cannot be inspected with immutable=1, while opening it
-    # normally may create or update sidecars. Fail closed instead.
+    # normally may create or update sidecars. Inspect the same canonical path
+    # that mutation will later open, and fail closed instead.
     for suffix in ("-wal", "-journal"):
         sidecar = Path(f"{path}{suffix}")
         try:
@@ -763,7 +785,7 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
 
     # immutable=1 prevents even a read-only SQLite connection from creating
     # WAL/SHM files while it inspects a quiescent existing target.
-    uri = f"{path.resolve().as_uri()}?mode=ro&immutable=1"
+    uri = f"{path.as_uri()}?mode=ro&immutable=1"
     try:
         conn = sqlite3.connect(uri, uri=True)
         try:
@@ -774,11 +796,14 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
                     "SELECT name FROM sqlite_master WHERE type = 'table'"
                 )
             }
-            existing_rows = 0
+            existing_ids: set[object] = set()
+            rows_without_ids = 0
             invalid_rows = 0
+            recognized_schema = False
             for table in ("working_memory", "episodic_memory"):
                 if table not in tables:
                     continue
+                recognized_schema = True
                 columns = {
                     row[1] for row in conn.execute(f"PRAGMA table_info({table})")
                 }
@@ -786,9 +811,14 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
                     raise SystemExit(
                         f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
                     )
-                row_count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
-                if table == "working_memory":
-                    existing_rows = row_count
+                if "id" in columns:
+                    existing_ids.update(
+                        row[0] for row in conn.execute(f"SELECT id FROM {table}")
+                    )
+                else:
+                    rows_without_ids += conn.execute(
+                        f"SELECT COUNT(*) FROM {table}"
+                    ).fetchone()[0]
                 invalid_rows += conn.execute(
                     f"""SELECT COUNT(*) FROM {table}
                         WHERE scope IS NULL OR scope != 'global'
@@ -797,9 +827,11 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
                 ).fetchone()[0]
 
             # The legacy mirror remains semantically readable and session-bound
-            # even after a row leaves working memory, so it must not carry a
-            # foreign or ambiguous session into a dedicated surface either.
+            # even after a row leaves working memory. Count IDs across all three
+            # stores once so mirrors require confirmation without double-counting
+            # one memory, and reject foreign or ambiguous sessions.
             if "memories" in tables:
+                recognized_schema = True
                 columns = {
                     row[1] for row in conn.execute("PRAGMA table_info(memories)")
                 }
@@ -807,12 +839,26 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
                     raise SystemExit(
                         f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
                     )
+                if "id" in columns:
+                    existing_ids.update(
+                        row[0] for row in conn.execute("SELECT id FROM memories")
+                    )
+                else:
+                    rows_without_ids += conn.execute(
+                        "SELECT COUNT(*) FROM memories"
+                    ).fetchone()[0]
                 invalid_rows += conn.execute(
                     """SELECT COUNT(*) FROM memories
                        WHERE session_id IS NULL OR session_id != ?""",
                     (session_id,),
                 ).fetchone()[0]
-            return existing_rows, invalid_rows
+
+            if not recognized_schema:
+                raise SystemExit(
+                    f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                )
+            existing_rows = len(existing_ids) + rows_without_ids
+            return path, existing_rows, invalid_rows
         finally:
             conn.close()
     except SystemExit:
@@ -855,13 +901,13 @@ def cmd_sync_init(args):
     )
     parsed = parser.parse_args(args)
 
-    existing_rows, invalid_rows = _sync_init_readonly_preflight(
+    target_path, existing_rows, invalid_rows = _sync_init_readonly_preflight(
         parsed.db_path, parsed.session_id
     )
     if invalid_rows:
         raise SystemExit(f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}")
     preview = {
-        "db_path": str(parsed.db_path),
+        "db_path": str(target_path),
         "session_id": parsed.session_id,
         "existing_rows": existing_rows,
         "invalid_rows": invalid_rows,
@@ -875,7 +921,7 @@ def cmd_sync_init(args):
     from mnemosyne.core.memory import Mnemosyne
     from mnemosyne.core.sync import SyncEngine
 
-    mem = Mnemosyne(db_path=parsed.db_path, session_id=parsed.session_id)
+    mem = Mnemosyne(db_path=target_path, session_id=parsed.session_id)
 
     SyncEngine(
         mem,

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -735,6 +735,36 @@ _SYNC_DEDICATED_DB_RECOVERY = (
 )
 
 
+# A sync-init claim may construct Mnemosyne and run schema migrations, so an
+# existing file must first match the complete table/column identity produced by
+# the current initializer. Older or partial layouts remain fail-closed until a
+# read-only compatibility proof is added for that exact layout.
+_SYNC_SCHEMA_FINGERPRINT = {
+    "working_memory": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "veracity", "created_at", "memory_type",
+        "consolidated_at", "consolidation_claimed_at", "recall_count",
+        "last_recalled", "pinned", "valid_until", "superseded_by", "scope",
+        "author_id", "author_type", "channel_id", "trust_tier", "validator",
+        "validated_at", "validation_count", "event_date",
+        "event_date_precision", "temporal_tags", "corrected_by",
+    }),
+    "episodic_memory": frozenset({
+        "rowid", "id", "content", "source", "timestamp", "session_id",
+        "importance", "metadata_json", "summary_of", "veracity", "created_at",
+        "tier", "degraded_at", "memory_type", "binary_vector", "recall_count",
+        "last_recalled", "valid_until", "superseded_by", "scope", "author_id",
+        "author_type", "channel_id", "trust_tier", "validator", "validated_at",
+        "validation_count", "event_date", "event_date_precision",
+        "temporal_tags", "corrected_by",
+    }),
+    "memories": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "created_at",
+    }),
+}
+
+
 def _sync_init_readonly_preflight(
     db_path: str, session_id: str
 ) -> tuple[Path, int, int]:
@@ -796,21 +826,26 @@ def _sync_init_readonly_preflight(
                     "SELECT name FROM sqlite_master WHERE type = 'table'"
                 )
             }
+            columns_by_table = {
+                table: {
+                    row[1] for row in conn.execute(f"PRAGMA table_info({table})")
+                }
+                for table in _SYNC_SCHEMA_FINGERPRINT
+                if table in tables
+            }
+            if any(
+                not required_columns.issubset(columns_by_table.get(table, set()))
+                for table, required_columns in _SYNC_SCHEMA_FINGERPRINT.items()
+            ):
+                raise SystemExit(
+                    f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                )
+
             existing_ids: set[object] = set()
             rows_without_ids = 0
             invalid_rows = 0
-            recognized_schema = False
             for table in ("working_memory", "episodic_memory"):
-                if table not in tables:
-                    continue
-                recognized_schema = True
-                columns = {
-                    row[1] for row in conn.execute(f"PRAGMA table_info({table})")
-                }
-                if not {"scope", "session_id"}.issubset(columns):
-                    raise SystemExit(
-                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
-                    )
+                columns = columns_by_table[table]
                 if "id" in columns:
                     existing_ids.update(
                         row[0] for row in conn.execute(f"SELECT id FROM {table}")
@@ -830,15 +865,8 @@ def _sync_init_readonly_preflight(
             # even after a row leaves working memory. Count IDs across all three
             # stores once so mirrors require confirmation without double-counting
             # one memory, and reject foreign or ambiguous sessions.
-            if "memories" in tables:
-                recognized_schema = True
-                columns = {
-                    row[1] for row in conn.execute("PRAGMA table_info(memories)")
-                }
-                if "session_id" not in columns:
-                    raise SystemExit(
-                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
-                    )
+            if "memories" in columns_by_table:
+                columns = columns_by_table["memories"]
                 if "id" in columns:
                     existing_ids.update(
                         row[0] for row in conn.execute("SELECT id FROM memories")
@@ -853,10 +881,6 @@ def _sync_init_readonly_preflight(
                     (session_id,),
                 ).fetchone()[0]
 
-            if not recognized_schema:
-                raise SystemExit(
-                    f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
-                )
             existing_rows = len(existing_ids) + rows_without_ids
             return path, existing_rows, invalid_rows
         finally:

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -768,25 +768,50 @@ def _sync_init_readonly_preflight(db_path: str, session_id: str) -> tuple[int, i
         conn = sqlite3.connect(uri, uri=True)
         try:
             conn.execute("PRAGMA query_only=ON")
-            table_exists = conn.execute(
-                """SELECT 1 FROM sqlite_master
-                   WHERE type = 'table' AND name = 'working_memory'"""
-            ).fetchone()
-            if table_exists is None:
-                return 0, 0
-            columns = {
-                row[1] for row in conn.execute("PRAGMA table_info(working_memory)")
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
             }
-            if not {"scope", "session_id"}.issubset(columns):
-                raise SystemExit(f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}")
-            existing_rows = conn.execute(
-                "SELECT COUNT(*) FROM working_memory"
-            ).fetchone()[0]
-            invalid_rows = conn.execute(
-                """SELECT COUNT(*) FROM working_memory
-                   WHERE scope != 'global' OR session_id != ?""",
-                (session_id,),
-            ).fetchone()[0]
+            existing_rows = 0
+            invalid_rows = 0
+            for table in ("working_memory", "episodic_memory"):
+                if table not in tables:
+                    continue
+                columns = {
+                    row[1] for row in conn.execute(f"PRAGMA table_info({table})")
+                }
+                if not {"scope", "session_id"}.issubset(columns):
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                row_count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+                if table == "working_memory":
+                    existing_rows = row_count
+                invalid_rows += conn.execute(
+                    f"""SELECT COUNT(*) FROM {table}
+                        WHERE scope IS NULL OR scope != 'global'
+                           OR session_id IS NULL OR session_id != ?""",
+                    (session_id,),
+                ).fetchone()[0]
+
+            # The legacy mirror remains semantically readable and session-bound
+            # even after a row leaves working memory, so it must not carry a
+            # foreign or ambiguous session into a dedicated surface either.
+            if "memories" in tables:
+                columns = {
+                    row[1] for row in conn.execute("PRAGMA table_info(memories)")
+                }
+                if "session_id" not in columns:
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                invalid_rows += conn.execute(
+                    """SELECT COUNT(*) FROM memories
+                       WHERE session_id IS NULL OR session_id != ?""",
+                    (session_id,),
+                ).fetchone()[0]
             return existing_rows, invalid_rows
         finally:
             conn.close()
@@ -835,11 +860,6 @@ def cmd_sync_init(args):
     )
     if invalid_rows:
         raise SystemExit(f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}")
-
-    from mnemosyne.core.memory import Mnemosyne
-    from mnemosyne.core.sync import SyncEngine
-
-    mem = Mnemosyne(db_path=parsed.db_path, session_id=parsed.session_id)
     preview = {
         "db_path": str(parsed.db_path),
         "session_id": parsed.session_id,
@@ -851,6 +871,11 @@ def cmd_sync_init(args):
         preview["required_flags"] = ["--claim-existing", "--yes"]
         print(json.dumps(preview, sort_keys=True))
         return
+
+    from mnemosyne.core.memory import Mnemosyne
+    from mnemosyne.core.sync import SyncEngine
+
+    mem = Mnemosyne(db_path=parsed.db_path, session_id=parsed.session_id)
 
     SyncEngine(
         mem,

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -725,6 +725,7 @@ def _read_secret_file(path: str, label: str) -> str:
 
 
 _DEFAULT_SYNC_SESSION_ID = "hermes_shared_surface"
+_DEFAULT_SYNC_SURFACE_ID = "shared-surface-v1"
 
 _SYNC_DEDICATED_DB_RECOVERY = (
     "The supplied database is not a dedicated shared-surface database. "
@@ -763,6 +764,19 @@ _SYNC_SCHEMA_FINGERPRINT = {
         "metadata_json", "created_at",
     }),
 }
+
+_SYNC_EVENT_BASE_COLUMNS = frozenset({
+    "event_id", "memory_id", "operation", "timestamp", "device_id", "payload",
+    "parent_event_ids", "importance", "expiry", "event_hash", "synced_at",
+})
+_SYNC_EVENT_SURFACE_COLUMNS = frozenset({
+    "timestamp_epoch", "surface_id", "apply_state",
+})
+_SYNC_META_COLUMNS = frozenset({"key", "value"})
+_SYNC_META_KEYS = frozenset({
+    "surface_db_id", "device_id", "configured_push_remote",
+})
+_SYNC_META_KEY_PREFIXES = ("last_pull_cursor_", "last_sync_at_")
 
 
 def _sync_init_readonly_preflight(
@@ -841,6 +855,84 @@ def _sync_init_readonly_preflight(
                     f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
                 )
 
+            surface_marker = None
+            if "sync_meta" in tables:
+                meta_info = conn.execute("PRAGMA table_info(sync_meta)").fetchall()
+                meta_columns = {row[1] for row in meta_info}
+                key_info = next((row for row in meta_info if row[1] == "key"), None)
+                value_info = next((row for row in meta_info if row[1] == "value"), None)
+                if (
+                    meta_columns != _SYNC_META_COLUMNS
+                    or key_info is None
+                    or value_info is None
+                    or str(key_info[2]).upper() != "TEXT"
+                    or str(value_info[2]).upper() != "TEXT"
+                    or key_info[5] != 1
+                    or value_info[5] != 0
+                ):
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                meta_rows = conn.execute("SELECT key, value FROM sync_meta").fetchall()
+                unknown_meta = [
+                    key for key, _value in meta_rows
+                    if not isinstance(key, str)
+                    or (
+                        key not in _SYNC_META_KEYS
+                        and not key.startswith(_SYNC_META_KEY_PREFIXES)
+                    )
+                ]
+                markers = [
+                    value for key, value in meta_rows if key == "surface_db_id"
+                ]
+                if unknown_meta or len(markers) > 1:
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                surface_marker = markers[0] if markers else None
+                if surface_marker not in (None, _DEFAULT_SYNC_SURFACE_ID):
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                # Metadata without a durable marker belongs to an unscoped
+                # sync engine and is ambiguous at the surface claim boundary.
+                if meta_rows and surface_marker is None:
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+
+            if "memory_events" in tables:
+                event_columns = {
+                    row[1] for row in conn.execute(
+                        "PRAGMA table_info(memory_events)"
+                    ).fetchall()
+                }
+                if not _SYNC_EVENT_BASE_COLUMNS.issubset(event_columns):
+                    raise SystemExit(
+                        f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                    )
+                event_count = conn.execute(
+                    "SELECT COUNT(*) FROM memory_events"
+                ).fetchone()[0]
+                if event_count:
+                    if (
+                        surface_marker != _DEFAULT_SYNC_SURFACE_ID
+                        or not _SYNC_EVENT_SURFACE_COLUMNS.issubset(event_columns)
+                    ):
+                        raise SystemExit(
+                            f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                        )
+                    invalid_events = conn.execute(
+                        """SELECT COUNT(*) FROM memory_events
+                           WHERE surface_id IS NULL OR surface_id != ?
+                              OR timestamp_epoch IS NULL""",
+                        (_DEFAULT_SYNC_SURFACE_ID,),
+                    ).fetchone()[0]
+                    if invalid_events:
+                        raise SystemExit(
+                            f"Refusing initialization: {_SYNC_DEDICATED_DB_RECOVERY}"
+                        )
+
             existing_ids: set[object] = set()
             rows_without_ids = 0
             invalid_rows = 0
@@ -859,6 +951,14 @@ def _sync_init_readonly_preflight(
                         WHERE scope IS NULL OR scope != 'global'
                            OR session_id IS NULL OR session_id != ?""",
                     (session_id,),
+                ).fetchone()[0]
+
+            working_columns = columns_by_table["working_memory"]
+            if "sync_surface_id" in working_columns:
+                invalid_rows += conn.execute(
+                    """SELECT COUNT(*) FROM working_memory
+                       WHERE sync_surface_id IS NOT NULL AND sync_surface_id != ?""",
+                    (_DEFAULT_SYNC_SURFACE_ID,),
                 ).fetchone()[0]
 
             # The legacy mirror remains semantically readable and session-bound
@@ -950,6 +1050,7 @@ def cmd_sync_init(args):
     SyncEngine(
         mem,
         surface_only=True,
+        surface_id=_DEFAULT_SYNC_SURFACE_ID,
         initialize_surface=True,
         claim_existing_surface=bool(existing_rows),
     )

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -232,14 +232,17 @@ def _snapshot_tree(root: Path) -> dict[str, tuple]:
 
 
 def _sync_init_subprocess(
-    tmp_path: Path, db_path: Path, *extra_args: str
+    tmp_path: Path,
+    db_path: Path,
+    *extra_args: str,
+    data_root: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
         {
             "HOME": str(tmp_path / "home"),
             "HERMES_HOME": str(tmp_path / "hermes-home"),
-            "MNEMOSYNE_DATA_DIR": str(tmp_path / "data-root"),
+            "MNEMOSYNE_DATA_DIR": str(data_root or (tmp_path / "data-root")),
             "MNEMOSYNE_NO_EMBEDDINGS": "1",
             "PYTHONDONTWRITEBYTECODE": "1",
         }
@@ -287,6 +290,113 @@ def test_sync_init_confirmation_is_filesystem_read_only_in_fresh_process(tmp_pat
     assert not Path(f"{db_path}-shm").exists()
     assert not (tmp_path / "data-root").exists()
     assert not (tmp_path / "hermes-home").exists()
+
+
+def test_sync_init_rejects_unrecognized_schema_read_only_in_fresh_process(tmp_path):
+    db_path = tmp_path / "unrelated.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE customer_records (id INTEGER PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO customer_records (value) VALUES ('must remain untouched')")
+    before = _snapshot_tree(tmp_path)
+
+    rejected = _sync_init_subprocess(
+        tmp_path, db_path, "--claim-existing", "--yes"
+    )
+
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+    assert not (tmp_path / "data-root").exists()
+    assert not (tmp_path / "hermes-home").exists()
+
+
+def test_sync_init_global_episodic_rows_require_confirmation_in_fresh_process(tmp_path):
+    data_root = tmp_path / "data-root"
+    db_path = tmp_path / "episodic-only.db"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "MNEMOSYNE_DATA_DIR": str(data_root),
+            "MNEMOSYNE_NO_EMBEDDINGS": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    setup = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import sys
+                from pathlib import Path
+                from mnemosyne.core.memory import Mnemosyne
+
+                memory = Mnemosyne(
+                    db_path=Path(sys.argv[1]),
+                    session_id="hermes_shared_surface",
+                )
+                memory.beam.conn.execute(
+                    "INSERT INTO episodic_memory "
+                    "(id, content, session_id, scope) VALUES (?, ?, ?, ?)",
+                    ("episode-1", "existing shared episode", "hermes_shared_surface", "global"),
+                )
+                memory.beam.conn.commit()
+                memory.beam.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                memory.beam.conn.close()
+                """
+            ),
+            str(db_path),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert setup.returncode == 0, setup.stderr
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0] == 1
+    before = _snapshot_tree(tmp_path)
+
+    confirmation = _sync_init_subprocess(tmp_path, db_path)
+
+    assert confirmation.returncode == 0, confirmation.stderr
+    assert json.loads(confirmation.stdout) == {
+        "db_path": str(db_path),
+        "existing_rows": 1,
+        "invalid_rows": 0,
+        "required_flags": ["--claim-existing", "--yes"],
+        "session_id": "hermes_shared_surface",
+        "status": "confirmation_required",
+    }
+    assert _snapshot_tree(tmp_path) == before
+
+    confirmed = _sync_init_subprocess(
+        tmp_path, db_path, "--claim-existing", "--yes"
+    )
+
+    assert confirmed.returncode == 0, confirmed.stderr
+    assert json.loads(confirmed.stdout)["claimed_rows"] == 1
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            "SELECT id, content, scope, session_id FROM episodic_memory"
+        ).fetchall() == [
+            (
+                "episode-1",
+                "existing shared episode",
+                "global",
+                "hermes_shared_surface",
+            )
+        ]
+        assert conn.execute(
+            "SELECT value FROM sync_meta WHERE key = 'surface_db_id'"
+        ).fetchone() == ("shared-surface-v1",)
 
 
 @pytest.mark.parametrize(
@@ -460,6 +570,43 @@ def test_sync_init_does_not_touch_hot_wal_or_shm(tmp_path):
         assert "uncheckpointed SQLite state" in rejected.stderr
         assert "not a dedicated shared-surface database" in rejected.stderr
         assert _snapshot_tree(tmp_path) == before
+    finally:
+        conn.close()
+
+
+def test_sync_init_rejects_hot_wal_symlink_alias_read_only_in_fresh_process(tmp_path):
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    db_path = data_root / "hot-shared.db"
+    alias = data_root / "shared-alias.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE working_memory (scope TEXT, session_id TEXT)")
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('global', 'hermes_shared_surface')"
+        )
+        conn.commit()
+        alias.symlink_to(db_path)
+        assert Path(f"{db_path}-wal").stat().st_size > 0
+        assert Path(f"{db_path}-shm").exists()
+        before = _snapshot_tree(tmp_path)
+
+        rejected = _sync_init_subprocess(
+            tmp_path,
+            alias,
+            "--claim-existing",
+            "--yes",
+            data_root=data_root,
+        )
+
+        assert rejected.returncode != 0
+        assert "symbolic-link database targets are not allowed" in rejected.stderr
+        assert _snapshot_tree(tmp_path) == before
+        assert alias.is_symlink()
+        assert data_root.exists()
+        assert Path(f"{db_path}-wal").exists()
+        assert Path(f"{db_path}-shm").exists()
     finally:
         conn.close()
 

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
 
 import pytest
 
@@ -105,12 +110,159 @@ def test_non_loopback_plain_http_sync_is_rejected(tmp_path):
         engine.get_status(remote_url="http://relay.example", api_key="secret")
 
 
+def _snapshot_tree(root: Path) -> dict[str, tuple]:
+    """Capture names, metadata, and file bytes for mutation comparisons."""
+    if not root.exists():
+        return {}
+    snapshot = {}
+    for path in sorted(root.rglob("*")):
+        stat_result = path.lstat()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else None
+        snapshot[str(path.relative_to(root))] = (
+            "file" if path.is_file() else "directory",
+            stat_result.st_mode,
+            stat_result.st_size,
+            stat_result.st_mtime_ns,
+            digest,
+        )
+    return snapshot
+
+
+def test_rejected_sync_init_is_filesystem_read_only_in_fresh_process(tmp_path):
+    data_root = tmp_path / "data"
+    db_path = data_root / "private.db"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "MNEMOSYNE_DATA_DIR": str(data_root),
+            "MNEMOSYNE_NO_EMBEDDINGS": "1",
+        }
+    )
+    setup = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from mnemosyne.core.memory import Mnemosyne; "
+                f"m = Mnemosyne(db_path={str(db_path)!r}, "
+                "session_id='hermes_shared_surface'); "
+                "m.remember('shared row', scope='global', source='test'); "
+                "m.remember('private row', scope='session', source='test')"
+            ),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert setup.returncode == 0, setup.stderr
+    before = _snapshot_tree(tmp_path)
+
+    rejected = subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", "sync-init", "--db-path", str(db_path)],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
+    assert "mnemosyne sync-init --db-path" in rejected.stderr
+    assert "mnemosyne_shared_*" in rejected.stderr
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+
+
+def test_sync_init_missing_target_does_not_create_data_root(tmp_path):
+    data_root = tmp_path / "absent-data"
+    hermes_home = tmp_path / "absent-hermes-home"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(hermes_home),
+            "MNEMOSYNE_DATA_DIR": str(data_root),
+        }
+    )
+
+    rejected = subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", "sync-init"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 2
+    assert "--db-path" in rejected.stderr
+    assert not data_root.exists()
+    assert not hermes_home.exists()
+
+
+def test_sync_init_does_not_touch_hot_wal_or_shm(tmp_path):
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    db_path = data_root / "hot-private.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            "CREATE TABLE working_memory (scope TEXT, session_id TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('session', 'private-session')"
+        )
+        conn.commit()
+        assert Path(f"{db_path}-wal").stat().st_size > 0
+        assert Path(f"{db_path}-shm").exists()
+        before = _snapshot_tree(tmp_path)
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(tmp_path / "home"),
+                "HERMES_HOME": str(tmp_path / "hermes-home"),
+                "MNEMOSYNE_DATA_DIR": str(data_root),
+            }
+        )
+
+        rejected = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mnemosyne.cli",
+                "sync-init",
+                "--db-path",
+                str(db_path),
+            ],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert rejected.returncode != 0
+        assert "uncheckpointed SQLite state" in rejected.stderr
+        assert "not a dedicated shared-surface database" in rejected.stderr
+        assert _snapshot_tree(tmp_path) == before
+    finally:
+        conn.close()
+
+
 def test_sync_init_requires_explicit_confirmation_for_existing_rows(tmp_path, capsys):
     from mnemosyne.cli import cmd_sync_init
 
     db_path = tmp_path / "legacy-shared.db"
     memory = Mnemosyne(db_path=db_path, session_id="hermes_shared_surface")
     memory.remember("existing shared", source="test", scope="global")
+    memory.beam.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
     cmd_sync_init(["--db-path", str(db_path)])
     preview = json.loads(capsys.readouterr().out)
@@ -120,6 +272,7 @@ def test_sync_init_requires_explicit_confirmation_for_existing_rows(tmp_path, ca
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sync_meta'"
     ).fetchone()
     assert sync_meta_exists is None
+    memory.beam.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
     cmd_sync_init(
         ["--db-path", str(db_path), "--claim-existing", "--yes"]

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import sqlite3
 import subprocess
 import sys
+import textwrap
 
 import pytest
 
@@ -65,6 +66,108 @@ def test_deployment_readme_initializes_client_surface_before_sync():
     assert init_command in client_section
     assert sync_command in client_section
     assert client_section.index(init_command) < client_section.index(sync_command)
+
+
+def test_documented_encrypted_sync_form_matches_and_executes_current_cli(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    sync_doc = (root / "docs" / "sync.md").read_text(encoding="utf-8")
+    cli_reference = (root / "docs" / "cli-reference.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "--encrypt-key-file \"$SYNC_KEY_FILE\"" in readme
+    documented_command = (
+        'mnemosyne sync --db-path "$SURFACE" \\\n'
+        "  --remote https://my-vps.example.com:8765 \\\n"
+        "  --encrypt-key-file mnemosyne-sync.key"
+    )
+    assert documented_command in sync_doc
+    assert "--encrypt <key>\\|--encrypt-key-file <path>" in cli_reference
+    assert "--prompt-key" not in sync_doc
+    assert "MNEMOSYNE_SYNC_KEY=" not in readme
+    assert "MNEMOSYNE_SYNC_KEY=" not in sync_doc
+    documented_sync_commands = [
+        line.strip()
+        for line in sync_doc.splitlines()
+        if line.strip().startswith("mnemosyne sync --")
+    ]
+    assert documented_sync_commands
+    assert all("--db-path" in command for command in documented_sync_commands)
+
+    cli_help = subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", "sync", "--help"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert cli_help.returncode == 0, cli_help.stderr
+    assert "--encrypt ENCRYPT" in cli_help.stdout
+    assert "--encrypt-key-file ENCRYPT_KEY_FILE" in cli_help.stdout
+    assert "--prompt-key" not in cli_help.stdout
+
+    key_file = tmp_path / "sync-encryption.key"
+    key_file.write_text("documented-test-key\n", encoding="utf-8")
+    if os.name != "nt":
+        key_file.chmod(0o600)
+    command_args = [
+        "--db-path",
+        str(tmp_path / "surface.db"),
+        "--remote",
+        "https://relay.example",
+        "--encrypt-key-file",
+        str(key_file),
+    ]
+    probe = textwrap.dedent(
+        """
+        import json
+        import sys
+        import types
+
+        memory_module = types.ModuleType("mnemosyne.core.memory")
+        memory_module.Mnemosyne = type("Mnemosyne", (), {"__init__": lambda self, **kwargs: None})
+        sync_module = types.ModuleType("mnemosyne.core.sync")
+
+        class SyncEncryption:
+            @classmethod
+            def from_config(cls, value):
+                assert value == "documented-test-key"
+                return value
+
+        class SyncEngine:
+            def __init__(self, memory, **kwargs):
+                assert kwargs["encryption"] == "documented-test-key"
+                assert kwargs["require_encryption"] is True
+
+            def sync_with(self, remote_url, mode, api_key):
+                return {
+                    "remote": remote_url,
+                    "mode": mode,
+                    "push": None,
+                    "pull": None,
+                    "errors": [],
+                }
+
+        sync_module.SyncEncryption = SyncEncryption
+        sync_module.SyncEngine = SyncEngine
+        sys.modules["mnemosyne.core.memory"] = memory_module
+        sys.modules["mnemosyne.core.sync"] = sync_module
+
+        from mnemosyne.cli import cmd_sync
+        cmd_sync(json.loads(sys.argv[1]))
+        """
+    )
+    executed = subprocess.run(
+        [sys.executable, "-c", probe, json.dumps(command_args)],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert executed.returncode == 0, executed.stderr
+    assert "Sync to https://relay.example" in executed.stdout
 
 
 def test_surface_mode_refuses_unmarked_db_without_claiming_rows(tmp_path):
@@ -126,6 +229,111 @@ def _snapshot_tree(root: Path) -> dict[str, tuple]:
             digest,
         )
     return snapshot
+
+
+def _sync_init_subprocess(
+    tmp_path: Path, db_path: Path, *extra_args: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "MNEMOSYNE_DATA_DIR": str(tmp_path / "data-root"),
+            "MNEMOSYNE_NO_EMBEDDINGS": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mnemosyne.cli",
+            "sync-init",
+            "--db-path",
+            str(db_path),
+            *extra_args,
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_sync_init_confirmation_is_filesystem_read_only_in_fresh_process(tmp_path):
+    db_path = tmp_path / "existing-global.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE working_memory (scope TEXT, session_id TEXT)")
+        conn.execute(
+            "INSERT INTO working_memory VALUES ('global', 'hermes_shared_surface')"
+        )
+    before = _snapshot_tree(tmp_path)
+
+    confirmation = _sync_init_subprocess(tmp_path, db_path)
+
+    assert confirmation.returncode == 0, confirmation.stderr
+    assert json.loads(confirmation.stdout) == {
+        "db_path": str(db_path),
+        "existing_rows": 1,
+        "invalid_rows": 0,
+        "required_flags": ["--claim-existing", "--yes"],
+        "session_id": "hermes_shared_surface",
+        "status": "confirmation_required",
+    }
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+    assert not (tmp_path / "data-root").exists()
+    assert not (tmp_path / "hermes-home").exists()
+
+
+@pytest.mark.parametrize(
+    ("scope", "session_id"),
+    [
+        (None, "hermes_shared_surface"),
+        ("global", None),
+    ],
+    ids=["null-scope", "null-session-id"],
+)
+def test_sync_init_null_ownership_is_read_only_in_fresh_process(
+    tmp_path, scope, session_id
+):
+    db_path = tmp_path / "ambiguous.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE working_memory (scope TEXT, session_id TEXT)")
+        conn.execute("INSERT INTO working_memory VALUES (?, ?)", (scope, session_id))
+    before = _snapshot_tree(tmp_path)
+
+    rejected = _sync_init_subprocess(
+        tmp_path, db_path, "--claim-existing", "--yes"
+    )
+
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+
+
+def test_sync_init_private_episodic_history_is_read_only_in_fresh_process(tmp_path):
+    db_path = tmp_path / "private-episodic.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE working_memory (scope TEXT, session_id TEXT)")
+        conn.execute("CREATE TABLE episodic_memory (scope TEXT, session_id TEXT)")
+        conn.execute("INSERT INTO episodic_memory VALUES ('session', 'private-session')")
+    before = _snapshot_tree(tmp_path)
+
+    rejected = _sync_init_subprocess(
+        tmp_path, db_path, "--claim-existing", "--yes"
+    )
+
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
 
 
 def test_rejected_sync_init_is_filesystem_read_only_in_fresh_process(tmp_path):

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -324,6 +324,104 @@ def test_sync_init_rejects_unrecognized_schema_read_only_in_fresh_process(tmp_pa
     assert not (tmp_path / "hermes-home").exists()
 
 
+@pytest.mark.parametrize(
+    ("setup", "db_name"),
+    [
+        (
+            """
+            from mnemosyne.core.sync import SyncEngine
+
+            engine = SyncEngine(memory, device_id="legacy-device", allow_unscoped_sync=True)
+            engine.log_event("legacy-memory", "CREATE", {"content": "legacy event"})
+            """,
+            "legacy-events.db",
+        ),
+        (
+            """
+            from mnemosyne.core.sync import SyncEngine
+
+            engine = SyncEngine(memory, device_id="foreign-device", allow_unscoped_sync=True)
+            engine.conn.execute(
+                "INSERT INTO sync_meta (key, value) VALUES (?, ?)",
+                ("surface_db_id", "foreign-surface"),
+            )
+            engine.conn.commit()
+            """,
+            "foreign-surface-meta.db",
+        ),
+    ],
+    ids=["legacy-unscoped-memory-event", "conflicting-surface-marker"],
+)
+def test_sync_init_rejects_existing_sync_state_read_only_in_fresh_process(
+    tmp_path, setup, db_name
+):
+    data_root = tmp_path / "data-root"
+    db_path = tmp_path / db_name
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "MNEMOSYNE_DATA_DIR": str(data_root),
+            "MNEMOSYNE_NO_EMBEDDINGS": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    created = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                from pathlib import Path
+                import sys
+                from mnemosyne.core.memory import Mnemosyne
+
+                memory = Mnemosyne(
+                    db_path=Path(sys.argv[1]),
+                    session_id="hermes_shared_surface",
+                )
+                """
+            )
+            + textwrap.dedent(setup)
+            + textwrap.dedent(
+                """
+                memory.beam.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                memory.beam.conn.close()
+                """
+            ),
+            str(db_path),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr
+    with sqlite3.connect(
+        f"{db_path.as_uri()}?mode=ro&immutable=1", uri=True
+    ) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    before = _snapshot_tree(tmp_path)
+
+    rejected = _sync_init_subprocess(
+        tmp_path,
+        db_path,
+        "--claim-existing",
+        "--yes",
+        data_root=data_root,
+    )
+
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
+    assert _snapshot_tree(tmp_path) == before
+    assert not Path(f"{db_path}-wal").exists()
+    assert not Path(f"{db_path}-shm").exists()
+
+
 def test_sync_init_global_episodic_rows_require_confirmation_in_fresh_process(tmp_path):
     data_root = tmp_path / "data-root"
     db_path = tmp_path / "episodic-only.db"
@@ -621,6 +719,25 @@ def test_sync_init_rejects_hot_wal_symlink_alias_read_only_in_fresh_process(tmp_
         assert Path(f"{db_path}-shm").exists()
     finally:
         conn.close()
+
+
+def test_sync_init_accepts_empty_existing_sync_tables(tmp_path, capsys):
+    from mnemosyne.cli import cmd_sync_init
+    from mnemosyne.core.sync import SyncEngine
+
+    db_path = tmp_path / "empty-sync-state.db"
+    memory = Mnemosyne(db_path=db_path, session_id="hermes_shared_surface")
+    engine = SyncEngine(memory, device_id="legacy-device", allow_unscoped_sync=True)
+    assert engine.conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0] == 0
+    assert engine.conn.execute("SELECT COUNT(*) FROM sync_meta").fetchone()[0] == 0
+    engine.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    cmd_sync_init(["--db-path", str(db_path)])
+
+    assert json.loads(capsys.readouterr().out)["status"] == "initialized"
+    assert engine.conn.execute(
+        "SELECT value FROM sync_meta WHERE key = 'surface_db_id'"
+    ).fetchone()[0] == "shared-surface-v1"
 
 
 def test_sync_init_requires_explicit_confirmation_for_existing_rows(tmp_path, capsys):

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -265,26 +265,38 @@ def _sync_init_subprocess(
     )
 
 
-def test_sync_init_confirmation_is_filesystem_read_only_in_fresh_process(tmp_path):
-    db_path = tmp_path / "existing-global.db"
+@pytest.mark.parametrize(
+    ("table", "schema", "row"),
+    [
+        (
+            "working_memory",
+            "scope TEXT, session_id TEXT",
+            ("global", "hermes_shared_surface"),
+        ),
+        (
+            "memories",
+            "id TEXT, session_id TEXT",
+            ("coincidental-id", "hermes_shared_surface"),
+        ),
+    ],
+    ids=["coincidental-working-memory", "coincidental-memories"],
+)
+def test_sync_init_rejects_coincidental_schema_read_only_in_fresh_process(
+    tmp_path, table, schema, row
+):
+    db_path = tmp_path / f"coincidental-{table}.db"
     with sqlite3.connect(db_path) as conn:
-        conn.execute("CREATE TABLE working_memory (scope TEXT, session_id TEXT)")
-        conn.execute(
-            "INSERT INTO working_memory VALUES ('global', 'hermes_shared_surface')"
-        )
+        conn.execute(f"CREATE TABLE {table} ({schema})")
+        placeholders = ", ".join("?" for _ in row)
+        conn.execute(f"INSERT INTO {table} VALUES ({placeholders})", row)
     before = _snapshot_tree(tmp_path)
 
-    confirmation = _sync_init_subprocess(tmp_path, db_path)
+    rejected = _sync_init_subprocess(
+        tmp_path, db_path, "--claim-existing", "--yes"
+    )
 
-    assert confirmation.returncode == 0, confirmation.stderr
-    assert json.loads(confirmation.stdout) == {
-        "db_path": str(db_path),
-        "existing_rows": 1,
-        "invalid_rows": 0,
-        "required_flags": ["--claim-existing", "--yes"],
-        "session_id": "hermes_shared_surface",
-        "status": "confirmation_required",
-    }
+    assert rejected.returncode != 0
+    assert "not a dedicated shared-surface database" in rejected.stderr
     assert _snapshot_tree(tmp_path) == before
     assert not Path(f"{db_path}-wal").exists()
     assert not Path(f"{db_path}-shm").exists()


### PR DESCRIPTION
## Summary

Fixes #543 by making rejected `sync-init` targets fail before Mnemosyne or SyncEngine initialization.

- preflights existing targets through a fail-closed, read-only SQLite path
- rejects private, ambiguous, foreign, legacy, hot-WAL, aliased, unrecognized, and incompatible sync-state targets without changing the database, sidecars, config, or data root
- keeps empty dedicated-surface initialization and explicit claiming of legitimate existing surface content
- documents the dedicated shared-surface topology and executable `--db-path` / `--encrypt-key-file` forms

## Why this path

The rejected path must be completely non-mutating. Constructing Mnemosyne first can create state or migrate before SyncEngine rejects a private/mixed target, defeating the guard. The preflight decides rejection before that mutable boundary.

## Non-goals

- no migration, export, or copying of private/session history
- no new sync protocol or surface semantics
- no generic database repair or hostile concurrent pathname-replacement model

## Verification

- fresh-process filesystem snapshots cover private/NULL/foreign rows, episodic and legacy-only content, hot WAL aliases, symlink/hardlink aliases, unknown and coincidental schemas, existing sync metadata, and legacy events
- `178 passed` across sync/security/CLI-relevant tests
- Ruff and Python syntax checks pass
- independent spec and final security reviews passed on the final head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `sync-init` now performs a fail-closed, read-only preflight before Mnemosyne or `SyncEngine` initialization.
- It rejects private, foreign, legacy, ambiguous, aliased, hot-WAL, and incompatible databases without changing files, sidecars, configuration, or the data root.
- Sync now requires a physically dedicated shared-surface database.
- Hermes populates the surface only through explicit `mnemosyne_shared_*` tools.
- `default_scope: global` affects new writes. It does not convert existing private or session history.
- The change preserves local-first privacy. It does not add migration, bulk export, copying, or repair.
- Working, episodic, and BEAM tiers, retrieval, consolidation, veracity, and benchmark methodology are unchanged.
- CLI and documentation now expose dedicated `--db-path` usage and key-file encryption forms.
- Fresh-process filesystem snapshots and security tests verify the non-mutating boundary.
- The dedicated surface is the right architectural choice. It provides a clear sync boundary and reduces accidental private-data exposure.
- No change erodes the local-first design. MCP and sync protocols remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->