### PR TITLE
Update Mnemosyne plugin command in documentation

### DIFF
--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -326,7 +326,7 @@ If Hermes reports the Mnemosyne plugin as disabled, enable it without requesting
 any built-in-tool override, then select it as the memory provider:
 
 ```powershell
-hermes plugins enable mnemosyne --no-allow-tool-override
+hermes plugins enable hermes-mnemosyne --no-allow-tool-override
 hermes config set memory.provider mnemosyne
 ```
 


### PR DESCRIPTION
## Description

Updating target plugin name from `mnemosyne` to `hermes-mnemosyne` to match the correct name.

## Related Issue

Closes #(issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [ ] Existing tests still pass (`pytest tests/ -v`)
- [ ] New tests added for any new functionality
- [X] Manual verification (describe what you tested)

Executed old command resulting in error.

``` bash
$ hermes plugins enable mnemosyne --no-allow-tool-override
Plugin 'mnemosyne' is not installed or bundled.

```

Executed new command resulting in success.

```bash
$ hermes plugins enable hermes-mnemosyne --no-allow-tool-override
✓ Plugin hermes-mnemosyne enabled. Takes effect on next session.
hermes-mnemosyne may not override built-in tools. Re-run `hermes plugins enable hermes-mnemosyne
--allow-tool-override` to grant this later.
```

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [ ] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrects the Hermes integration command to enable `hermes-mnemosyne`.
- Restores the documented Hermes integration path. The old `mnemosyne` identifier fails because the plugin is not bundled or installed.
- Does not change Mnemosyne’s memory architecture, privacy posture, local-first guarantees, retrieval, consolidation, veracity, sync, benchmarks, MCP surface, or CLI behavior.
- Improves maintainability by aligning documentation with the current plugin identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->