### PR TITLE
docs: refresh Hermes wrapper after upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,13 @@ Mnemosyne exposes memory, knowledge-graph, multi-agent-surface, working-note, an
 
 ```bash
 export HERMES_HOME=/opt/data  # Replace with the active Hermes home
-"$HERMES_HOME/.mnemosyne/venv/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+VENV="$HERMES_HOME/.mnemosyne/venv"
+"$VENV/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+"$VENV/bin/mnemosyne-hermes" install --mode wrapper --force --python "$VENV/bin/python"
 hermes gateway restart
 ```
+
+The forced install regenerates the wrapper plugin files and does not modify the Mnemosyne database.
 
 For a direct or source install, use `pip install --upgrade mnemosyne-hermes && hermes gateway restart` or `git pull && pip install --upgrade integrations/hermes && hermes gateway restart` (source).
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -211,9 +211,15 @@ Both Path A's wrapper installer and Path B's `python -m mnemosyne.install` regis
 ```bash
 # Path A: persistent side venv + wrapper
 export HERMES_HOME=/opt/data  # Replace with the active Hermes home
-"$HERMES_HOME/.mnemosyne/venv/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+VENV="$HERMES_HOME/.mnemosyne/venv"
+"$VENV/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+"$VENV/bin/mnemosyne-hermes" install --mode wrapper --force --python "$VENV/bin/python"
 hermes gateway restart
+```
 
+The forced install regenerates the wrapper plugin files and does not modify the Mnemosyne database.
+
+```bash
 # Path B: direct PyPI install
 pip install --upgrade mnemosyne-memory
 hermes gateway restart


### PR DESCRIPTION
## Summary

- Refresh the generated Hermes wrapper after upgrading the persistent side venv.
- Use the selected venv Python explicitly and document that the refresh does not modify the Mnemosyne database.

## Scope

This is a documentation-only correction for the Path A update flow in the README and LLM installation guide. It does not change runtime code, database behavior, or other installation paths.

## Why this path

The wrapper installer owns the generated plugin files. A package upgrade alone does not refresh an existing wrapper directory, so restarting without rerunning the installer can leave required files missing.

Why not document only an upgrade and restart: that preserves the stale generated wrapper and does not restore the current CLI surface.

## Validation

- `git diff --check origin/main...HEAD`
- Read-only Python assertions verified both update blocks contain the forced wrapper refresh with the selected venv Python and the database safety note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documents the Path A refresh flow after upgrading the persistent Hermes side virtual environment.
- Uses the selected venv Python to force regeneration of wrapper plugin files.
- Notes that the refresh does not modify the Mnemosyne database.

## Architectural impact

- No changes to tiered memory, retrieval, consolidation, veracity, sync, or benchmark systems.
- No changes to Mnemosyne’s core memory architecture or privacy posture.
- Preserves local-first guarantees because the change only updates local installation documentation.
- Improves the Hermes integration surface by preventing stale generated wrapper files after upgrades.
- Does not change MCP, CLI, runtime behavior, database behavior, or other installation paths.
- Improves maintainability by making the required post-upgrade refresh explicit.

This is the right call for a documentation-only fix. It preserves local-first design and avoids unnecessary runtime or database changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->