### PR TITLE
fix(recall): align unknown vec routing diagnostics

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -796,6 +796,8 @@ def _mark_vec_store_norm_bit(conn) -> None:
 
 
 _legacy_warning_emitted = False
+_unknown_marker_warning_emitted = False
+_unknown_marker_warning_lock = threading.Lock()
 
 
 def _warn_vec_store_legacy_once() -> None:
@@ -813,6 +815,21 @@ def _warn_vec_store_legacy_once() -> None:
         "candidates. Run reindex_vectors() once to normalize stored "
         "rows and switch to the fast KNN path."
     )
+
+
+def _warn_vec_store_unknown_once() -> None:
+    """Warn once per process when the normalized-format marker is unreadable."""
+    global _unknown_marker_warning_emitted
+    if _unknown_marker_warning_emitted:
+        return
+    with _unknown_marker_warning_lock:
+        if _unknown_marker_warning_emitted:
+            return
+        _unknown_marker_warning_emitted = True
+        logger.warning(
+            "vec store format marker unreadable: conservative exact-cosine "
+            "scan selected"
+        )
 
 
 def _env_vec_admit() -> float:
@@ -8559,12 +8576,8 @@ class BeamMemory:
                     if _regime == "legacy":
                         _warn_vec_store_legacy_once()
                     else:
-                        logger.warning(
-                            "vec store format marker unreadable: using the "
-                            "conservative full-scan exact-cosine route for "
-                            "episodic vector candidates this call"
-                        )
-                    logger.info(
+                        _warn_vec_store_unknown_once()
+                    logger.debug(
                         "vec store regime=%s: episodic candidates via "
                         "full-scan blob scoring this call",
                         _regime,
@@ -8692,7 +8705,7 @@ class BeamMemory:
                             sim = _vec_distance_sim(vr["distance"], _vec_type)
                         vec_results[vr["rowid"]] = sim
                 if explain and _explain_trace is not None:
-                    if _regime == "legacy":
+                    if _regime != "pure":
                         _explain_trace.set_vec_mode("legacy_scan")
                     elif _vec_type == "bit":
                         _explain_trace.set_vec_mode("knn_bit")
@@ -8702,8 +8715,8 @@ class BeamMemory:
                         _explain_trace.set_vec_mode("knn_int8")
                     else:
                         _explain_trace.set_vec_mode("in_memory")
-                if _regime == "legacy" and len(vec_results) > max(top_k * 3, 20):
-                    # Legacy full-scan produced more candidates than the
+                if _regime != "pure" and len(vec_results) > max(top_k * 3, 20):
+                    # Conservative full-scan produced more candidates than the
                     # KNN path ever would: keep the top-k by exact cosine
                     # so downstream IN() hydration stays bounded.
                     _keep = set(sorted(
@@ -9365,7 +9378,8 @@ class BeamMemory:
                 _uv & _VEC_NORM_BIT
             )
         except Exception as exc:
-            logger.warning(
+            _warn_vec_store_unknown_once()
+            logger.debug(
                 "enhanced-recall cache: user_version read failed (%s); "
                 "caching disabled for this call", type(exc).__name__,
             )

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -76,6 +76,60 @@ def _close_memory(memory: BeamMemory | None) -> None:
         memory.conn.close()
 
 
+def test_unreadable_marker_bypasses_enhanced_cache_without_log_spam(
+    enhanced, monkeypatch, caplog
+):
+    memory, calls = enhanced
+    marker_reads = []
+    cache_calls = []
+
+    class CacheSpy:
+        def get_opaque(self, key):
+            cache_calls.append(("get", key))
+
+        def put_opaque(self, key, results):
+            cache_calls.append(("put", key, results))
+
+        def close(self):
+            pass
+
+    memory._query_cache = CacheSpy()
+    conn_type = type(memory.conn)
+    real_execute = conn_type.execute
+
+    def execute_without_user_version(conn, sql, parameters=(), *args, **kwargs):
+        normalized = (
+            sql.strip().rstrip(";").casefold() if isinstance(sql, str) else ""
+        )
+        if normalized == "pragma user_version":
+            marker_reads.append(sql)
+            raise RuntimeError("marker header unreadable")
+        return real_execute(conn, sql, parameters, *args, **kwargs)
+
+    monkeypatch.setattr(conn_type, "execute", execute_without_user_version)
+    monkeypatch.setattr(beam_module, "_unknown_marker_warning_emitted", False)
+
+    with caplog.at_level(logging.DEBUG, logger="mnemosyne.core.beam"):
+        first = _call(memory, "unknown marker")
+        second = _call(memory, "unknown marker")
+
+    assert len(marker_reads) == 2
+    assert len(calls) == 2
+    assert first != second
+    assert cache_calls == []
+    marker_warnings = [
+        record for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "vec store format marker unreadable" in record.getMessage()
+    ]
+    assert len(marker_warnings) == 1
+    assert not any(
+        record.levelno == logging.INFO
+        and "full-scan blob scoring this call" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 @pytest.mark.parametrize("previous_version", [6, 7])
 def test_cache_version_bump_invalidates_staged_and_admission_entries(
     enhanced, monkeypatch, tmp_path: Path, previous_version: int

--- a/tests/test_vec_regressions.py
+++ b/tests/test_vec_regressions.py
@@ -10,8 +10,10 @@
 """
 from __future__ import annotations
 
+import logging
 import math
-
+import queue
+import threading
 from pathlib import Path
 
 import numpy as np
@@ -179,6 +181,39 @@ class TestLegacyStoreClassification:
         assert after - before == 1, (
             f"expected exactly one legacy warning, got {after - before}"
         )
+
+    def test_unknown_marker_warning_is_thread_safe(self, monkeypatch, caplog):
+        callers = 8
+        start = threading.Barrier(callers)
+        outcomes = queue.Queue()
+
+        def call_warning():
+            try:
+                start.wait(timeout=5)
+                bm._warn_vec_store_unknown_once()
+            except Exception as exc:
+                outcomes.put(exc)
+            else:
+                outcomes.put(None)
+
+        monkeypatch.setattr(bm, "_unknown_marker_warning_emitted", False)
+        caplog.clear()
+        threads = [threading.Thread(target=call_warning) for _ in range(callers)]
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
+
+        assert not any(thread.is_alive() for thread in threads)
+        results = [outcomes.get_nowait() for _ in threads]
+        assert results == [None] * callers
+        marker_warnings = [
+            record for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "vec store format marker unreadable" in record.getMessage()
+        ]
+        assert len(marker_warnings) == 1
 
 
     @requires_vec
@@ -828,6 +863,11 @@ class TestBoundaryRoutingRegression:
             and "vec store format marker unreadable" in record.getMessage()
         ]
         assert len(marker_warnings) == 1
+        assert any(
+            record.levelno == logging.DEBUG
+            and "full-scan blob scoring this call" in record.getMessage()
+            for record in caplog.records
+        )
         assert not any(
             record.levelno == 20
             and "full-scan blob scoring this call" in record.getMessage()

--- a/tests/test_vec_regressions.py
+++ b/tests/test_vec_regressions.py
@@ -675,11 +675,8 @@ class TestBoundaryRoutingRegression:
     exact-cosine full scan."""
 
     @requires_vec
-    @pytest.mark.parametrize(
-        "marker_readable", [True, False], ids=["unmarked", "marker-read-error"]
-    )
     def test_mid_table_legacy_target_found_by_recall(
-            self, temp_db, monkeypatch, marker_readable):
+            self, temp_db, monkeypatch, caplog):
         import json as _json
         import sqlite3 as _sqlite3
         import sqlite_vec
@@ -768,30 +765,77 @@ class TestBoundaryRoutingRegression:
         monkeypatch.setattr(bm._embeddings, "embed_query", FakeEmb.embed_query)
         monkeypatch.setattr(bm._embeddings, "embed", FakeEmb.embed)
 
+        knn_calls = []
+        real_knn = bm._vec_search_with_blobs
+
+        def knn_spy(conn, emb, k=20):
+            knn_calls.append(k)
+            return real_knn(conn, emb, k)
+
+        monkeypatch.setattr(bm, "_vec_search_with_blobs", knn_spy)
+
+        legacy = beam.recall("mid-table legacy target zqxz", top_k=5)
+
         marker_reads = []
-        if not marker_readable:
-            conn_type = type(beam.conn)
-            real_execute = conn_type.execute
+        conn_type = type(beam.conn)
+        real_execute = conn_type.execute
 
-            def execute_without_user_version(
-                    conn, sql, parameters=(), *args, **kwargs):
-                normalized = (
-                    sql.strip().rstrip(";").casefold()
-                    if isinstance(sql, str)
-                    else ""
+        def execute_without_user_version(
+                conn, sql, parameters=(), *args, **kwargs):
+            normalized = (
+                sql.strip().rstrip(";").casefold()
+                if isinstance(sql, str)
+                else ""
+            )
+            if normalized == "pragma user_version":
+                marker_reads.append(sql)
+                raise _sqlite3.OperationalError("marker header unreadable")
+            return real_execute(conn, sql, parameters, *args, **kwargs)
+
+        monkeypatch.setattr(conn_type, "execute", execute_without_user_version)
+        monkeypatch.setattr(bm, "_unknown_marker_warning_emitted", False)
+        caplog.clear()
+        with caplog.at_level(10, logger="mnemosyne.core.beam"):
+            unknown_explained = beam.recall(
+                "mid-table legacy target zqxz", top_k=5, explain=True
+            )
+            unknown_again = beam.recall("mid-table legacy target zqxz", top_k=5)
+
+        assert len(marker_reads) == 2, "regression did not deny both marker reads"
+        assert unknown_explained["explain"].get("vec_mode") == "legacy_scan"
+        unknown = unknown_explained["results"]
+
+        def result_signature(results):
+            return [
+                (
+                    result["id"],
+                    {
+                        key: value
+                        for key, value in result.items()
+                        if key == "score" or key.endswith("_score")
+                    },
                 )
-                if normalized == "pragma user_version":
-                    marker_reads.append(sql)
-                    raise _sqlite3.OperationalError("marker header unreadable")
-                return real_execute(conn, sql, parameters, *args, **kwargs)
+                for result in results
+            ]
 
-            monkeypatch.setattr(conn_type, "execute", execute_without_user_version)
+        assert result_signature(unknown) == result_signature(legacy)
+        assert result_signature(unknown_again) == result_signature(legacy)
+        assert not knn_calls, "non-pure regimes must not use the raw-L2 KNN path"
 
-        res = beam.recall("mid-table legacy target zqxz", top_k=5)
-        if not marker_readable:
-            assert marker_reads, "regression did not deny the marker read"
+        marker_warnings = [
+            record for record in caplog.records
+            if record.levelno == 30
+            and "vec store format marker unreadable" in record.getMessage()
+        ]
+        assert len(marker_warnings) == 1
+        assert not any(
+            record.levelno == 20
+            and "full-scan blob scoring this call" in record.getMessage()
+            for record in caplog.records
+        )
+
         row = next(
-            (r for r in res if r.get("content") == "mid-table legacy target zqxz"),
+            (r for r in unknown if r.get("content") == "mid-table legacy target zqxz"),
             None,
         )
         assert row is not None, "mid-table legacy target missing from recall"


### PR DESCRIPTION
Closes #951.

## Contract

- Keep `pure` / `legacy` / `unknown` classification and retrieval behavior unchanged. Only confirmed-pure stores use or report KNN.
- Route unreadable markers through the existing conservative exact-cosine scan and report `vec_mode=legacy_scan` in Explain output.
- Emit one concurrency-safe unknown-marker warning per process across normal and enhanced recall paths.
- Keep enhanced-recall marker failures cacheless, with no fallback cache key, cache read, or cache write.
- Move the routine full-scan status message from INFO to DEBUG.

`mnemosyne/core/beam.py` owns both the routing diagnostic and enhanced cache-key boundary, so it is the narrow intervention point.

## Reproduction and regression coverage

Starting state: a sqlite-vec store whose `PRAGMA user_version` read is denied.

Action: call public `BeamMemory.recall(..., explain=True)` twice, and call enhanced recall twice.

Expected: exact-cosine scan, `legacy_scan`, one stable warning, no INFO full-scan spam, and enhanced cache bypass.

Before this change, Explain reported `knn_float32` for the denied-marker case and warning/status messages repeated.

## Non-goals

No #950 JSON fusion, schema/marker/reindex/writer/lifecycle changes, scoring/ranking/admission/candidate/cache-key redesign, Polyphonic Explain changes, broad logging work, CLI/MCP/provider/docs/changelog changes, or labels.

Why not create a fallback cache key: an unreadable marker cannot prove whether cached pure-store KNN results are compatible, so bypass remains the conservative boundary.

## Verification

- `uv run --frozen --extra embeddings --extra test pytest -q tests/test_vec_regressions.py tests/test_enhanced_recall_cache.py` → `81 passed`
- `uv run --frozen --extra dev ruff check --select F,RUF022 -- mnemosyne/core/beam.py tests/test_vec_regressions.py tests/test_enhanced_recall_cache.py` → passed
- `uv run --frozen --extra dev ruff check --select E9 -- mnemosyne/core/beam.py tests/test_vec_regressions.py tests/test_enhanced_recall_cache.py` → passed
- `uv run --frozen python -m py_compile mnemosyne/core/beam.py tests/test_vec_regressions.py tests/test_enhanced_recall_cache.py` → passed
- `git diff HEAD^ --check` → passed

The focused regression was also sabotaged by restoring the old unknown Explain predicate; it failed with `knn_float32` instead of `legacy_scan`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reports unreadable sqlite-vec markers as `legacy_scan` in recall diagnostics and Explain output.
- Preserves conservative exact-cosine scanning, candidate selection, ranking, fallback behavior, and enhanced-recall cache bypass.
- Emits one concurrency-safe unknown-marker warning per process.
- Moves routine full-scan status logging to DEBUG.
- Adds regression coverage for normal, enhanced, and concurrent recall behavior.

## Architectural impact

- **BEAM retrieval:** Improves diagnostics without changing pure, legacy, or unknown routing. Unknown markers continue to use exact-cosine scanning.
- **Tiered memory and consolidation:** No changes.
- **Retrieval strategies:** The PR clarifies the reported strategy for unknown markers. It does not change candidate selection or ranking.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** Preserved. The change adds no external service, network path, or new data flow.
- **Hermes, MCP, and CLI surfaces:** No integration contract changes.
- **Maintainability:** Centralized warning throttling, lower routine log volume, explicit `legacy_scan` reporting, and regression tests improve operational clarity.

Using exact-cosine scanning for unknown markers is the right call. It preserves safe retrieval behavior while making the conservative route visible. Nothing in this change erodes the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->